### PR TITLE
Updated Argo workflow with detailed readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,25 +284,28 @@ e. Check the PVs
 
 ## Run the Workflow
 
-### Declare the ip address of the metashape license server
+### 1. Declare the ip address of the metashape license server
 
-On the master node terminal, type:
+On the master instance terminal, type:
 
 `export AGISOFT_FLS=<ip_address>:5842`
 
 <br/>
 
-### Run!!
+### 2. Run!!
 
 ```
 argo submit -n argo workflow.yaml --watch \
--p AGISOFT_FLS=$AGISOFT_FLS \
--p RUN_FOLDER=gillan_test_0620 \
--p DATASET_LIST=datasets.txt
+-p AGISOFT_FLS=$AGISOFT_FLS \ ## specifies metashape license
+-p RUN_FOLDER=gillan_test_0620 \  ## output folder name that is written to /ofo-share/argo-output
+-p DATASET_LIST=datasets.txt  ## datasets to be processed as discussed in step 1 of Setup
 ```
 <br/>
 
 ### Monitor Argo Workflow
+
+
+
 
 ![argo_workflow](https://github.com/user-attachments/assets/b2b1d6db-3543-4156-bd61-14ddc725b095)
 

--- a/README.md
+++ b/README.md
@@ -331,9 +331,7 @@ c. Now go to a browser (firefox) in the WebDesktop and go the address:
 <br/>
  The 'Workflows' tab on the left side menu shows you all running workflows. If you click a current workflow, it will show you a schematic of the jobs spread across multiple instances. 
 
-<br/>
 
-![argo_workflow](https://github.com/user-attachments/assets/b2b1d6db-3543-4156-bd61-14ddc725b095)
 
 <br/>
 <br/>

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You need to specify which datasets to be processed in the file `/ofo-share/datas
 
 ### 2. Specify Metashape Parameters
 
-All metashape parameters are specified in a config.yml file which is located at `/ofo-share/argo-output`. You can create your own config yml as long as it is kept in this directory. The exact file (e.g., config2.yml or <projectname>_config.yml) will be specified as a parameter in the argo run command later in this workflow. 
+All metashape parameters are specified in a config.yml file which is located at `/ofo-share/argo-output`. You can create your own config yml as long as it is kept in this directory. The exact file (e.g., config2.yml or projectname_config.yml) will be specified as a parameter in the argo run command later in this workflow. 
 
 <br/>
 <br/>

--- a/README.md
+++ b/README.md
@@ -305,8 +305,9 @@ argo submit -n argo workflow.yaml --watch \
 <br/>
 
 argo submit -n argo workflow.yaml --watch \
+-p CONFIG_PATH=/ofo-share/argo-output/config.yml \
 -p AGISOFT_FLS=$AGISOFT_FLS \
--p RUN_FOLDER=gillan_test_0626 \
+-p RUN_FOLDER=gillan_test_test \
 -p DATASET_LIST=datasets.txt  
 
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Describe a specific node in your cluster
 <br/>
 
 ### 5. Install Argo on Master instance
-The following commands will download argo, unzip it, and bring it into your system path ready for use. 
+a. The following commands will download argo, unzip it, and bring it into your system path ready for use. 
 
 ```
 # Detect OS
@@ -120,21 +120,21 @@ The output of `argo version` should look like this:
 <br/>
 <br/>
 
-Create a isolated environment for the argo workflow on kubernetes
+b. Create a isolated environment for the argo workflow on kubernetes
 
 `kubectl create namespace argo`
 
 <br/>
 <br/>
 
-Put argo on to new environment on kubernetes. Controller & Server
+c. Put argo on to new environment on kubernetes. Controller & Server
 
 `kubectl apply -n argo -f https://github.com/argoproj/argo-workflows/releases/download/v3.6.5/install.yaml`
 
 <br/>
 <br/>
 
-Check if pods are running
+d. Check if pods are running
 
 `kubectl get pods -n argo`
 
@@ -143,14 +143,14 @@ Check if pods are running
 <br/>
 <br/>
 
-Describe pods
+e. Describe pods
 
 `kubectl describe pod <pod-name> -n argo`
 
 <br/>
 <br/>
 
-Set up ofo-srv role in argo
+f. Set up ofo-srv role in argo
 
 `kubectl create role ofo-argo-srv -n argo --verb=list,update, --resource=workflows.argoproj.io`
 
@@ -199,14 +199,14 @@ EOF
 <br/>
 <br/>
 
-Run the following command. The output should say 'yes'.
+g. Run the following command. The output should say 'yes'.
 
 `kubectl auth can-i create workflowtaskresults.argoproj.io -n argo --as=system:serviceaccount:argo:argo`
 
 <br/>
 <br/>
 
-Optional: check roles and role-bindings
+h. Optional: check roles and role-bindings
 
 `kubectl get role -n argo`
 

--- a/README.md
+++ b/README.md
@@ -392,36 +392,29 @@ During an automate-metashape run, we update an entry as the run progresses. We d
 
 ### Access and Navigation of postgis DB  
 
-* SSH into ofo-postgis
-
-`ssh exouser@<ip>`
+* SSH into ofo-postgis `ssh exouser@<ip>`
 
 
-* Enter the Docker container running the PostGIS server
-
-`sudo docker exec -ti ofo-postgis bash`
+* Enter the Docker container running the PostGIS server `sudo docker exec -ti ofo-postgis bash`
 
 
-* Launch the PostgreSQL CLI as the intended user (grab from DB credentials)
+* Launch the PostgreSQL CLI as the intended user (grab from DB credentials) `psql -U postgres`
 
-`psql -U postgres`
+* List all tables in the database `\dt`
 
-* List all tables in the database
+* Show the structure of a specific table (column names & data types) `\d automate_metashape`
 
-`\dt`
-
-* Show the structure of a specific table (column names & data types)
-
-`\d automate_metashape`
-
-* View all data records for a specific table
-
-`select * from automate_metashape;`
+* View all data records for a specific table `select * from automate_metashape;`
 
 
 
 
-
+<br/>
+<br/>
+<br/>
+<br/>
+<br/>
+<br/>
 
 
 

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ If you click on a specific job, it will show you lots of information of the proc
 
 ## Argo Workflow Logging in postGIS database (in development)
 
-There is a [development branch of `ofo-argo`](https://github.com/open-forest-observatory/ofo-argo/tree/aa_setup_argo_utils) repo created by Arnav. This branch has developed a workflow to log argo process status (eg., started, finished, successful, failed) into a postGIS DB. This is done through an additional docker container (hosted on ghcr). The workflow is in the folder `ofo-argo-utils`. There is also a github action workflow that rebuilds this container if changes have been made in `workflow.yml`. This workflow is in the directory `.github/workflows`.
+There is a [development branch of `ofo-argo`](https://github.com/open-forest-observatory/ofo-argo/tree/aa_setup_argo_utils) repo created by Arnav. This branch has developed a workflow to log argo process status (eg., started, finished, successful, failed) into a postGIS DB. This is done through an additional docker container (hosted on ghcr). The workflow is in the folder `ofo-argo-utils`. There is also a github action workflow that rebuilds this container if changes have been made in `workflow.yml`. This workflow is in the directory `.github/workflows`. There is an outstanding pull request regarding this development. 
 
 To run this experimental workflow navigate to the `ofo-argo` repo and go into the branch `git checkout aa_setup_argo_utils`
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository contains [Argo Workflows](https://argoproj.github.io/workflows) 
 The drone data to be processed and the workflow outputs are on the `ofo-share` volume. This volume will be automatically mounted to any VM built from `ofo-dev` image using [Exosphere interface](https://jetstream2.exosphere.app/exosphere/). The volume is mounted at `/ofo-share` of the VM. 
 <br/>
 
-To add new drone imagery projects to be processed using Argo, transfer files from your local machine to the `/ofo-share` volume.
+To add new drone imagery datasets to be processed using Argo, transfer files from your local machine to the `/ofo-share` volume.
 
 `scp -r <local/directory/drone_images> exouser@<vm.ip.address>:/ofo-share/`
 
@@ -316,6 +316,8 @@ On the master instance terminal, type:
 
 `export AGISOFT_FLS=<ip_address>:5842`
 
+This variable will only last during the terminal session and will have to be re-declared each time you start a new master terminal. 
+
 <br/>
 
 ### 2. Run!!
@@ -324,11 +326,16 @@ On the master instance terminal, type:
 argo submit -n argo workflow.yaml --watch \
 -p CONFIG_FILE=config2.yml \
 -p AGISOFT_FLS=$AGISOFT_FLS \
--p RUN_FOLDER=gillan_test \
+-p RUN_FOLDER=gillan_test_june27 \
 -p DATASET_LIST=datasets.txt  
 ```
 
+CONFIG_FILE is the config which specifies the metashape parameters which should be located in `/ofo-share/argo-output`
+AGISOFT_FLS is the ip address of the metashape license server
+RUN_FOLDER is what you want to name the parent directory of your output
+DATSET_LIST is the txt file where you specified the names of the datasets you want to process located at `/ofo-share/argo-output`
 
+<br/>
 
 ### 3. Monitor Argo Workflow
 The Argo UI is great for troubleshooting and checking additional logs. You can access it with the following steps
@@ -369,6 +376,14 @@ If you click on a specific job, it will show you lots of information of the proc
 
 <br/>
 <br/>
+
+### 4. Metashape Outputs
+The metashape outputs will be written to `/ofo-share/argo-outputs/<RUN_FOLDER>`. Each dataset will have its own subdirectory in the <RUN_FOLDER>. Output imagery products (DEMs, orthomosaics, point clouds, report) will be written to `/ofo-share/argo-outputs/<RUN_FOLDER>/<dataset_name>/output`. Metashape projects .psx will be written to `/ofo-share/argo-outputs/<RUN_FOLDER>/<dataset_name>/project`.
+
+
+
+
+
 <br/>
 <br/>
 <br/>

--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ The path for metashape output is: `/ofo-share/argo-output`
 You need to specify which datasets to be processed in the file `/ofo-share/datasets.txt`
 
 
-so the far the benchmarking datasets are: 
-
 <br/>
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -302,7 +302,9 @@ argo submit -n argo workflow.yaml --watch \
 ```
 <br/>
 <br/>
+
 For running the workflow with postGIS db
+
 ```
 argo submit -n argo workflow.yaml --watch \
   -p AGISOFT_FLS=$AGISOFT_FLS \

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Describe a specific node in your cluster
 <br/>
 <br/>
 
-### 6 Label each worker VM with a common role (for load-balancing)
+### 6. Label each worker VM with a common role (for load-balancing)
 
 Once each worker is labeled with a role, we will be able to ensure a VM has a single metashape project (unless there are more projects than nodes)
 
@@ -115,6 +115,8 @@ for node in $(kubectl get nodes --no-headers | awk '{print $1}'); do
   fi
 done
 ```
+<br/>
+<br/>
 
 ### 7. Install Argo on Master instance
 a. The following commands will download argo, unzip it, and bring it into your system path ready for use. 

--- a/README.md
+++ b/README.md
@@ -304,12 +304,13 @@ argo submit -n argo workflow.yaml --watch \
 <br/>
 <br/>
 
+```
 argo submit -n argo workflow.yaml --watch \
 -p CONFIG_FILE=/ofo-share/argo-output/config.yml \
 -p AGISOFT_FLS=$AGISOFT_FLS \
 -p RUN_FOLDER=gillan_test_test \
 -p DATASET_LIST=datasets.txt  
-
+```
 
 
 

--- a/README.md
+++ b/README.md
@@ -331,8 +331,11 @@ argo submit -n argo workflow.yaml --watch \
 ```
 
 CONFIG_FILE is the config which specifies the metashape parameters which should be located in `/ofo-share/argo-output`
+
 AGISOFT_FLS is the ip address of the metashape license server
+
 RUN_FOLDER is what you want to name the parent directory of your output
+
 DATSET_LIST is the txt file where you specified the names of the datasets you want to process located at `/ofo-share/argo-output`
 
 <br/>

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ On the master instance terminal, type:
 argo submit -n argo workflow.yaml --watch \
 -p AGISOFT_FLS=$AGISOFT_FLS \ ## specifies metashape license
 -p RUN_FOLDER=gillan_test_0620 \  ## output folder name that is written to /ofo-share/argo-output
--p DATASET_LIST=datasets.txt  ## datasets to be processed as discussed in step 1 of Setup
+-p DATASET_LIST=datasets.txt  ## datasets to be processed as discussed in [step 1 of Setup](./README.md#1-add-drone-imagery-data-to-ofo-shared-volume)
 ```
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -298,13 +298,30 @@ On the master instance terminal, type:
 argo submit -n argo workflow.yaml --watch \
 -p AGISOFT_FLS=$AGISOFT_FLS \ ## specifies metashape license
 -p RUN_FOLDER=gillan_test_0620 \  ## output folder name that is written to /ofo-share/argo-output
--p DATASET_LIST=datasets.txt  ## datasets to be processed as discussed in [step 1 of Setup](#1-add-drone-imagery-data-to-ofo-shared-volume)
+-p DATASET_LIST=datasets.txt  ## datasets to be processed as discussed in step 1 of Setup
 ```
 <br/>
 
-[step 1 of Setup](#1-add-drone-imagery-data-to-ofo-shared-volume)
 
-### Monitor Argo Workflow
+### 3. Monitor Argo Workflow
+The Argo UI is great for troubleshooting and checking additional logs. You can access it with the following steps
+
+a. In the CACAO interface, launch a WebDesktop for your master instance
+
+<img width="660" alt="Screenshot 2025-06-20 at 9 33 53 AM" src="https://github.com/user-attachments/assets/a3ee09ba-d701-4fa5-97d3-586b4c640dc1" />
+
+b. Launch a terminal in the WebDesktop and type the following
+
+`argo server --auth-mode server -n argo`
+
+c. Now go to a browser (firefox) in the WebDesktop and go the address:
+
+`https://<master_public_ip_address>:2746`
+
+<img width="1190" alt="Screenshot 2025-06-20 at 12 48 46 PM" src="https://github.com/user-attachments/assets/bd6bd991-f108-4be9-a1aa-6cb0f1ab1db5" />
+
+
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -297,7 +297,6 @@ On the master instance terminal, type:
 
 ```
 argo submit -n argo workflow.yaml --watch \
--p config_path=/ofo-share/argo-output/config.yml \
 -p AGISOFT_FLS=$AGISOFT_FLS \ ## specifies metashape license
 -p RUN_FOLDER=gillan_test_0626 \  ## output folder name that is written to /ofo-share/argo-output
 -p DATASET_LIST=datasets.txt  ## datasets to be processed as discussed in step 1 of Setup
@@ -306,7 +305,6 @@ argo submit -n argo workflow.yaml --watch \
 <br/>
 
 argo submit -n argo workflow.yaml --watch \
--p config_path=/ofo-share/argo-output/config.yml \
 -p AGISOFT_FLS=$AGISOFT_FLS \
 -p RUN_FOLDER=gillan_test_0626 \
 -p DATASET_LIST=datasets.txt  

--- a/README.md
+++ b/README.md
@@ -344,7 +344,29 @@ If you click on a specific job, it will show you lots of information of the proc
 <br/>
 <br/>
 
-## PostGIS Database
+## ofo-argo-utils
+There is a subfolder in ofo-argo called ofo-argo-utils. The intention of this is to contain code that helps with utility functions for automate-metashape (or in the future, any other data pipeline tasks). Right now, the main functionality is handling database logging (see more below). There is a GitHub actions workflow setup to automatically build an image for ofo-argo-utils on commits to ofo-argo. The purpose of this image is so that we can reference it in our Argo Workflows for reusability and portability. Here is an example of the image being used:
+
+<img width="422" alt="Screenshot 2025-06-20 at 4 50 00 PM" src="https://github.com/user-attachments/assets/a9a5ccf9-6197-4223-94b3-e1b140e928d1" />
+
+<br/>
+
+### PostGIS Database
+There is a JS2 VM called ofo-postgis that hosts a postgis DB. When we process drone imagery in Metashape, we want some information to be put into this postGIS database. 
+
+```
+argo submit -n argo workflow.yaml --watch \
+  -p AGISOFT_FLS=$AGISOFT_FLS \
+  -p RUN_FOLDER=$RUN_FOLDER \
+  -p DATASET_LIST=$DATASET_LIST \
+  -p DB_PASSWORD=$DB_PASSWORD \
+  -p DB_HOST=$DB_HOST \
+  -p DB_NAME=$DB_NAME \
+  -p DB_USER=$DB_USER
+```
+Replace the variables above (e.g., $AGISOFT_FLS, $RUN_FOLDER) with your actual environment values or export them beforehand. Get all variables associated with the database from the internal credentials doc.
+
+
 
 
 ## Files In this Repository

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ b. Create a isolated environment for the argo workflow on kubernetes
 <br/>
 <br/>
 
-c. Put argo on to new environment on kubernetes. Controller & Server
+c. Put argo on to new environment on kubernetes. Installs workflow Controller which manages overall lifecycle of workflows. Also installs argo server which includes a web-based user interface. 
 
 `kubectl apply -n argo -f https://github.com/argoproj/argo-workflows/releases/download/v3.6.5/install.yaml`
 

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ argo submit -n argo workflow.yaml --watch \
 <br/>
 
 argo submit -n argo workflow.yaml --watch \
--p CONFIG_PATH=/ofo-share/argo-output/config.yml \
+-p CONFIG_FILE=/ofo-share/argo-output/config.yml \
 -p AGISOFT_FLS=$AGISOFT_FLS \
 -p RUN_FOLDER=gillan_test_test \
 -p DATASET_LIST=datasets.txt  

--- a/README.md
+++ b/README.md
@@ -310,20 +310,26 @@ a. In the CACAO interface, launch a WebDesktop for your master instance
 
 <img width="660" alt="Screenshot 2025-06-20 at 9 33 53 AM" src="https://github.com/user-attachments/assets/a3ee09ba-d701-4fa5-97d3-586b4c640dc1" />
 
+<br/>
+
 b. Launch a terminal in the WebDesktop and type the following
 
 `argo server --auth-mode server -n argo`
+
+<br/>
 
 c. Now go to a browser (firefox) in the WebDesktop and go the address:
 
 `https://<master_public_ip_address>:2746`
 
+<br/>
+
 <img width="1190" alt="Screenshot 2025-06-20 at 12 48 46 PM" src="https://github.com/user-attachments/assets/bd6bd991-f108-4be9-a1aa-6cb0f1ab1db5" />
 
 
 
-
-
+<br/>
+<br/>
 
 
 ![argo_workflow](https://github.com/user-attachments/assets/b2b1d6db-3543-4156-bd61-14ddc725b095)

--- a/README.md
+++ b/README.md
@@ -305,19 +305,7 @@ argo submit -n argo workflow.yaml --watch \
 <br/>
 <br/>
 
-For running the workflow with postGIS db
 
-```
-argo submit -n argo workflow.yaml --watch \
-  -p AGISOFT_FLS=$AGISOFT_FLS \
-  -p RUN_FOLDER=$RUN_FOLDER \
-  -p DATASET_LIST=$DATASET_LIST \
-  -p DB_PASSWORD=$DB_PASSWORD \
-  -p DB_HOST=$DB_HOST \
-  -p DB_NAME=$DB_NAME \
-  -p DB_USER=$DB_USER
-```
-Replace the variables above (e.g., $AGISOFT_FLS, $RUN_FOLDER) with your actual environment values or export them beforehand. Get all variables associated with the database from the internal credentials doc.
 
 
 
@@ -361,11 +349,32 @@ If you click on a specific job, it will show you lots of information of the proc
 <br/>
 <br/>
 <br/>
+<br/>
+<br/>
+<br/>
 
+## Argo Workflow Logging in postGIS database (in development)
 
-## Argo Workflow Logging in postGIS database
+There is a [development branch of `ofo-argo`](https://github.com/open-forest-observatory/ofo-argo/tree/aa_setup_argo_utils) repo created by Arnav. This branch has developed a workflow to log argo process status (eg., started, finished, successful, failed) into a postGIS DB. This is done through an additional docker container (hosted on ghcr). The workflow is in the folder `ofo-argo-utils`. There is also a github action workflow that rebuilds this container if changes have been made in `workflow.yml`. This workflow is in the directory `.github/workflows`.
 
-There is a JS2 VM called `ofo-postgis` that hosts a postgis DB in docker. When we process drone imagery in Metashape, we want workflow  information to be put into this postGIS database. This server has persistent storage, tied to a storage volume made in Jetstream.
+To run this experimental workflow navigate to the `ofo-argo` repo and go into the branch `git checkout aa_setup_argo_utils`
+
+<br/>
+
+```
+argo submit -n argo workflow.yaml --watch \
+  -p AGISOFT_FLS=$AGISOFT_FLS \
+  -p RUN_FOLDER=$RUN_FOLDER \
+  -p DATASET_LIST=$DATASET_LIST \
+  -p DB_PASSWORD=$DB_PASSWORD \
+  -p DB_HOST=$DB_HOST \
+  -p DB_NAME=$DB_NAME \
+  -p DB_USER=$DB_USER
+```
+Replace the variables above (e.g., $AGISOFT_FLS, $RUN_FOLDER) with your actual environment values or export them beforehand. Get all variables associated with the database from the internal credentials doc.
+
+### Info on the postGIS DB
+There is a JS2 VM called `ofo-postgis` that hosts a postgis DB in docker. When we process drone imagery in Metashape, we want workflow metadata to be put into this postGIS database. This server has persistent storage, tied to a storage volume made in Jetstream.
 
 As of right now, the PostGIS server stores the following keys:
 
@@ -379,17 +388,21 @@ As of right now, the PostGIS server stores the following keys:
 | finish_time  | timestamp without time zone | end time of automate-metashape run (if it was able to finish) |
 | created_at | timestamp without time zone | creation time of entry in database |
 
+### Access and Navigation of postgis DB  
 
+* SSH into ofo-postgis `ssh exouser@<ip>`
+
+* Enter the Docker container running the PostGIS server `sudo docker exec -ti ofo-postgis bash`
+
+* Launch the PostgreSQL CLI as the intended user (grab from DB credentials) `psql -U postgres`
+
+* List all tables in the database `\dt`
+
+* Show the structure of a specific table (column names & data types) `\d automate_metashape`
+
+* View all data records for a specific table `select * from automate_metashape;`
 
 ## ofo-argo-utils
-in the `ofo-argo-utils` directory: 
-
-a docker file to create an image with python and some libraries
-
-a requirements.txt the defines the python libraries to install on the docker image
-
-db_logger.py - python code to log argo workflow status into the postgis DM
-
 
 <br/>
 <br/>
@@ -405,19 +418,7 @@ During an automate-metashape run, we update an entry as the run progresses. We d
 
 
 
-### Access and Navigation of postgis DB  
 
-* SSH into ofo-postgis `ssh exouser@<ip>`
-
-* Enter the Docker container running the PostGIS server `sudo docker exec -ti ofo-postgis bash`
-
-* Launch the PostgreSQL CLI as the intended user (grab from DB credentials) `psql -U postgres`
-
-* List all tables in the database `\dt`
-
-* Show the structure of a specific table (column names & data types) `\d automate_metashape`
-
-* View all data records for a specific table `select * from automate_metashape;`
 
 
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ You need to specify which datasets to be processed in the file `/ofo-share/datas
 
 All metashape parameters are specified in a config.yml file which is located at '/ofo-share/argo-output`. You can create your own config yml as long as it is kept in this directory. The exact file (e.g., config2.yml or <projectname>_config.yml) will be specified as a parameter in the argo run command later in this workflow. 
 
+<br/>
+<br/>
+
 ### 3. Lauch VMs with CACAO
 
 CACAO is an interface for provisioning and launching virtual machines on Jetstream2 Cloud. OFO is using this interface because it has the ability to quickly launch multiple VMs with kubernetes pre-installed. This capability does not currently exist in Exosphere (the default UI for JS2). 

--- a/README.md
+++ b/README.md
@@ -298,8 +298,9 @@ On the master instance terminal, type:
 
 ```
 argo submit -n argo workflow.yaml --watch \
+-p CONFIG_FILE=config2.yml \
 -p AGISOFT_FLS=$AGISOFT_FLS \
--p RUN_FOLDER=gillan_test_test \
+-p RUN_FOLDER=gillan_test \
 -p DATASET_LIST=datasets.txt  
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ You can connect to the terminal of any of the VMs through two methods:
 <img width="660" alt="Screenshot 2025-06-20 at 9 33 53 AM" src="https://github.com/user-attachments/assets/a3ee09ba-d701-4fa5-97d3-586b4c640dc1" />
 
 #### SSH into the VM from your local terminal or IDE
-`ssh exouser@<vm_public_ip_address>`
+`ssh <access_username>@<vm_public_ip_address>`
+
+IMPORTANT NOTE. If you have launched VMs from Cacao, the ssf username is **<access_username>**! I you launch VMs from Exosphere, the ssh username is **exouser**!
 
 <br/>
 <br/>

--- a/README.md
+++ b/README.md
@@ -344,6 +344,9 @@ If you click on a specific job, it will show you lots of information of the proc
 <br/>
 <br/>
 
+## PostGIS Database
+
+
 ## Files In this Repository
 
 | File Name   | Purpose       |

--- a/README.md
+++ b/README.md
@@ -275,6 +275,9 @@ e. Check the PVs
 
 `kubectl get pvc -n argo`
 
+<br/>
+<br/>
+
 ## Run the Workflow
 
 ### Declare the ip address of the metashape license server
@@ -293,6 +296,7 @@ argo submit -n argo workflow.yaml --watch \
 -p RUN_FOLDER=gillan_test_0620 \
 -p DATASET_LIST=datasets.txt
 ```
+<br/>
 
 ### Monitor Argo Workflow
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The drone data to be processed and the workflow outputs are on the `ofo-share` v
 
 To add new drone imagery projects to be processed using Argo, transfer files from your local machine to the `/ofo-share` volume.
 
-`scp -r <local/directory/drone_images> exouser@<vm.ip.address:/ofo-share/`
+`scp -r <local/directory/drone_images> exouser@<vm.ip.address>:/ofo-share/`
 
 Put the drone imagery projects to be processed in it's own directory in `/ofo-share`. For example, there are 4 testing datasets already in the directory called `benchmarking-inputs`, `emerald-point-benchmark`, `benchmarking-swetnam-house`, `benchmarking-greasewood`
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You need to specify which datasets to be processed in the file `/ofo-share/datas
 
 ### 2. Specify Metashape Parameters
 
-All metashape parameters are specified in a config.yml file which is located at '/ofo-share/argo-output`. You can create your own config yml as long as it is kept in this directory. The exact file (e.g., config2.yml or <projectname>_config.yml) will be specified as a parameter in the argo run command later in this workflow. 
+All metashape parameters are specified in a config.yml file which is located at `/ofo-share/argo-output`. You can create your own config yml as long as it is kept in this directory. The exact file (e.g., config2.yml or <projectname>_config.yml) will be specified as a parameter in the argo run command later in this workflow. 
 
 <br/>
 <br/>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 This repository contains [Argo Workflows](https://argoproj.github.io/workflows) used by the **Open Forest Observatory (OFO)**. It is being developed to run the [automate-metashape](https://github.com/open-forest-observatory/automate-metashape) pipeline simultaneously across multiple virtual machines on [Jetstream2 Cloud](https://jetstream-cloud.org/). This type of scaling enables OFO to process many photogrammetry projects simultaneously (instead of sequentially) and vastly reduce total processing time. Argo is meant to work on [Kubernetes](https://kubernetes.io/docs/concepts/overview/) which orchestrates containers (ie, automate-metashape in docker), scales the processing to multiple VMs, and balances the load between the VMs. 
 
-Outputs of the metashape runs are intended to be automatically funneled into a postGIS DB.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -297,13 +297,19 @@ On the master instance terminal, type:
 
 ```
 argo submit -n argo workflow.yaml --watch \
+-p config_path=/ofo-share/argo-output/config.yml \
 -p AGISOFT_FLS=$AGISOFT_FLS \ ## specifies metashape license
--p RUN_FOLDER=gillan_test_0620 \  ## output folder name that is written to /ofo-share/argo-output
+-p RUN_FOLDER=gillan_test_0626 \  ## output folder name that is written to /ofo-share/argo-output
 -p DATASET_LIST=datasets.txt  ## datasets to be processed as discussed in step 1 of Setup
 ```
 <br/>
 <br/>
 
+argo submit -n argo workflow.yaml --watch \
+-p config_path=/ofo-share/argo-output/config.yml \
+-p AGISOFT_FLS=$AGISOFT_FLS \
+-p RUN_FOLDER=gillan_test_0626 \
+-p DATASET_LIST=datasets.txt  
 
 
 

--- a/README.md
+++ b/README.md
@@ -243,13 +243,39 @@ a. Install Network File System (NFS) on all instances including the master and e
 
 `sudo apt install nfs-common -y`
 
+`sudo reboot`
+
+<br/>
+
+b. Reconnect to the master instance and navigate into the cloned repository
+
+`cd ~/ofo-argo`
+
+<br/>
+
+c. Set up the persistent volumes (PV) defined by the workflow. You are specifying the read (raw drone imagery on `ofo-share`) and the write (metashape output location)
+
+`kubectl apply -f argo-output-pv.yaml`
+
+`kubectl apply -f ofo-share-pv.yaml`
+
+<br/>
+
+d. Set up persistent volume claims (PVC)
+
+`kubectl apply -f argo-output-pvc.yaml -n argo`
+
+`kubectl apply -f ofo-share-pvc.yaml -n argo`
+
+<br/>
+
+e. Check the PVs
+
+`kubectl get pv`
+
+`kubectl get pvc -n argo`
 
 
-
-
-persistent volume (PV)
-
-persistent volume claim (PVC)
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -233,9 +233,19 @@ In the home directory of your terminal, type in the following
 
 <br/>
 
-### 6. Connect VM instances to shared volume
+### 7. Connect VM instances to shared volume
 
-The following is about connecting the kubernetes instances with the `/ofo-share` volume so it can read the drone imagery to process and write the outputs.
+The following is about connecting the VM instances with the `/ofo-share` volume so it can read the drone imagery to process and write the outputs.
+
+a. Install Network File System (NFS) on all instances including the master and each worker. You will need to connect to each VM terminal to do installation. 
+
+`sudo apt update`
+
+`sudo apt install nfs-common -y`
+
+
+
+
 
 persistent volume (PV)
 

--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ a. In the CACAO interface, launch a WebDesktop for your master instance
 <img width="660" alt="Screenshot 2025-06-20 at 9 33 53 AM" src="https://github.com/user-attachments/assets/a3ee09ba-d701-4fa5-97d3-586b4c640dc1" />
 
 <br/>
+<br/>
 
 b. Launch a terminal in the WebDesktop and type the following
 
@@ -326,14 +327,20 @@ c. Now go to a browser (firefox) in the WebDesktop and go the address:
 
 <img width="1190" alt="Screenshot 2025-06-20 at 12 48 46 PM" src="https://github.com/user-attachments/assets/bd6bd991-f108-4be9-a1aa-6cb0f1ab1db5" />
 
-
-
 <br/>
 <br/>
+ The 'Workflows' tab on the left side menu shows you all running workflows. If you click a current workflow, it will show you a schematic of the jobs spread across multiple instances. 
 
+<br/>
 
 ![argo_workflow](https://github.com/user-attachments/assets/b2b1d6db-3543-4156-bd61-14ddc725b095)
 
+<br/>
+<br/>
+
+If you click on a specific job, it will show you lots of information of the process including which VM it is running on, the duration of the process, and logs. 
+
+<img width="1190" alt="Screenshot 2025-06-20 at 12 58 55 PM" src="https://github.com/user-attachments/assets/ab10f2b4-3120-47be-b1dd-601687707f0c" />
 
 <br/>
 <br/>

--- a/README.md
+++ b/README.md
@@ -13,18 +13,24 @@ This repository contains [Argo Workflows](https://argoproj.github.io/workflows) 
 ### 1. Add drone imagery data to OFO shared volume
 
 The drone data to be processed and the workflow outputs are on the `ofo-share` volume. This volume will be automatically mounted to any VM built from `ofo-dev` image using [Exosphere interface](https://jetstream2.exosphere.app/exosphere/). The volume is mounted at `/ofo-share` of the VM. 
+<br/>
 
 To add new drone imagery projects to be processed using Argo, transfer files from your local machine to the `/ofo-share` volume.
 
 `scp -r <local/directory/drone_images> exouser@<vm.ip.address:/ofo-share/`
 
-location of drone imagery projects to be processed: `/ofo-share`
+Put the drone imagery projects to be processed in it's own directory in `/ofo-share`. For example, there are 4 testing datasets already in the directory called `benchmarking-inputs`, `emerald-point-benchmark`, `benchmarking-swetnam-house`, `benchmarking-greasewood`
 
-Path for metashape output: `/ofo-share-serve/argo-output`
+The path for metashape output is: `/ofo-share/argo-output`
+
+<br/>
+
+#### Specify which datasets to process in Argo
 
 You need to specify which datasets to be processed in the file `/ofo-share/datasets.txt`
 
-so the far the benchmarking datasets are: benchmarking-inputs, emerald-point-benchmark, benchmarking-swetnam-house, benchmarking-greasewood
+
+so the far the benchmarking datasets are: 
 
 <br/>
 <br/>

--- a/README.md
+++ b/README.md
@@ -373,6 +373,9 @@ argo submit -n argo workflow.yaml --watch \
 ```
 Replace the variables above (e.g., $AGISOFT_FLS, $RUN_FOLDER) with your actual environment values or export them beforehand. Get all variables associated with the database from the internal credentials doc.
 
+During an automate-metashape run, we update an entry in the db as the run progresses. We do NOT add new rows to update the status. Moving forward, we might want to see if this is the best practice.
+
+
 ### Info on the postGIS DB
 There is a JS2 VM called `ofo-postgis` that hosts a postgis DB in docker. When we process drone imagery in Metashape, we want workflow metadata to be put into this postGIS database. This server has persistent storage, tied to a storage volume made in Jetstream.
 
@@ -401,26 +404,6 @@ As of right now, the PostGIS server stores the following keys:
 * Show the structure of a specific table (column names & data types) `\d automate_metashape`
 
 * View all data records for a specific table `select * from automate_metashape;`
-
-## ofo-argo-utils
-
-<br/>
-<br/>
-
-There is a subfolder in ofo-argo called ofo-argo-utils. The intention of this is to contain code that helps with utility functions for automate-metashape (or in the future, any other data pipeline tasks). Right now, the main functionality is handling database logging (see more below). There is a GitHub actions workflow setup to automatically build an image for ofo-argo-utils on commits to ofo-argo. The purpose of this image is so that we can reference it in our Argo Workflows for reusability and portability. Here is an example of the image being used:
-
-During an automate-metashape run, we update an entry as the run progresses. We do NOT add new rows to update the status. Moving forward, we might want to see if this is the best practice.
-
-
-<img width="422" alt="Screenshot 2025-06-20 at 4 50 00 PM" src="https://github.com/user-attachments/assets/a9a5ccf9-6197-4223-94b3-e1b140e928d1" />
-
-<br/>
-
-
-
-
-
-
 
 
 

--- a/README.md
+++ b/README.md
@@ -377,22 +377,13 @@ As of right now, the PostGIS server stores the following keys:
 | **Column**   | **Type** | **Description**  |
 |  --- | ----  | --- |
 |id | integer | unique identifier for each call of automate-metashape (not run) |
-| |  |
+|dataset_name | character varying(100) | dataset running for the individual call of automate-metashape |
+| workflow_id | character varying(100) | identifier for run of ofo-argo |
+| status | character varying(50)  | either queued, processing, or failed, based on current and final status of automate-metashape |
+| start_time | timestamp without time zone | start time of automate-metashape run |
+| finish_time  | timestamp without time zone | end time of automate-metashape run (if it was able to finish) |
+| created_at | timestamp without time zone | creation time of entry in database |
 
-
-* id: unique identifier for each call of automate-metashape (not run)
-  
-* dataset-name: dataset running for the individual call of automate-metashape
-  
-* workflow-id: identifier for run of ofo-argo
-
-* status: either queued, processing, or failed, based on current and final status of automate-metashape
-
-* start_time: start time of automate-metashape run
-
-* end_time: end time of automate-metashape run (if it was able to finish)
-
-* created_at: creation time of entry in database
 
 During an automate-metashape run, we update an entry as the run progresses. We do NOT add new rows to update the status. Moving forward, we might want to see if this is the best practice.
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You can connect to the terminal of any of the VMs through two methods:
 #### SSH into the VM from your local terminal or IDE
 `ssh <access_username>@<vm_public_ip_address>`
 
-IMPORTANT NOTE. If you have launched VMs from Cacao, the ssf username is **<access_username>**! I you launch VMs from Exosphere, the ssh username is **exouser**!
+IMPORTANT NOTE. If you have launched VMs from Cacao, the ssh username is **<access_username>**! If you launch VMs from Exosphere, the ssh username is **exouser**!
 
 <br/>
 <br/>

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ b. Launch a terminal in the WebDesktop and type the following
 
 <br/>
 
-c. Now go to a browser (firefox) in the WebDesktop and go the address:
+c. Now go to a browser (firefox) in the WebDesktop and go the address. You may receive a "Connection not secure" error but just bypass it.
 
 `https://<master_public_ip_address>:2746`
 

--- a/README.md
+++ b/README.md
@@ -369,38 +369,54 @@ There is a subfolder in ofo-argo called ofo-argo-utils. The intention of this is
 
 <br/>
 
-### PostGIS Database
-There is a JS2 VM called ofo-postgis that hosts a postgis DB in docker. When we process drone imagery in Metashape, we want some information to be put into this postGIS database. This server has persistent storage, tied to a storage volume made in Jetstream.
+## PostGIS Database
+There is a JS2 VM called `ofo-postgis` that hosts a postgis DB in docker. When we process drone imagery in Metashape, we want some information to be put into this postGIS database. This server has persistent storage, tied to a storage volume made in Jetstream.
 
-As of right now, the PostGIS server stores the following keys
-id: unique identifier for each call of automate-metashape (not run)
-dataset-name: dataset running for the individual call of automate-metashape
-workflow-id: identifier for run of ofo-argo
-status: either queued, processing, or failed, based on current and final status of automate-metashape
-start_time: start time of automate-metashape run
-end_time: end time of automate-metashape run (if it was able to finish)
-created_at: creation time of entry in database
+As of right now, the PostGIS server stores the following keys:
+
+* id: unique identifier for each call of automate-metashape (not run)
+  
+* dataset-name: dataset running for the individual call of automate-metashape
+  
+* workflow-id: identifier for run of ofo-argo
+
+* status: either queued, processing, or failed, based on current and final status of automate-metashape
+
+* start_time: start time of automate-metashape run
+
+* end_time: end time of automate-metashape run (if it was able to finish)
+
+* created_at: creation time of entry in database
 
 During an automate-metashape run, we update an entry as the run progresses. We do NOT add new rows to update the status. Moving forward, we might want to see if this is the best practice.
 
-1. SSH into ofo-postgis
+### Access and Navigation of postgis DB  
 
-`ssh <user>@<ip>`
+* SSH into ofo-postgis
+
+`ssh exouser@<ip>`
 
 
-2. Enter the Docker container running the PostGIS server
+* Enter the Docker container running the PostGIS server
 
 `sudo docker exec -ti ofo-postgis bash`
 
 
-3. Launch the PostgreSQL CLI as the intended user (grab from DB credentials)
+* Launch the PostgreSQL CLI as the intended user (grab from DB credentials)
 
-`psql -U <user>`
+`psql -U postgres`
 
+* List all tables in the database
 
-4. View table
+`\dt`
 
-`SELECT * FROM automate_metashape;`
+* Show the structure of a specific table (column names & data types)
+
+`\d automate_metashape`
+
+* View all data records for a specific table
+
+`select * from automate_metashape;`
 
 
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ location of drone imagery projects to be processed: `/ofo-share`
 
 Path for metashape output: `/ofo-share-serve/argo-output`
 
-
+You need to specify which datasets to be processed in the file `/ofo-share/datasets.txt`
 
 so the far the benchmarking datasets are: benchmarking-inputs, emerald-point-benchmark, benchmarking-swetnam-house, benchmarking-greasewood
 
@@ -275,8 +275,30 @@ e. Check the PVs
 
 `kubectl get pvc -n argo`
 
+## Run the Workflow
+
+### Declare the ip address of the metashape license server
+
+On the master node terminal, type:
+
+`export AGISOFT_FLS=<ip_address>:5842`
+
+<br/>
+
+### Run!!
+
+```
+argo submit -n argo workflow.yaml --watch \
+-p AGISOFT_FLS=$AGISOFT_FLS \
+-p RUN_FOLDER=gillan_test_0620 \
+-p DATASET_LIST=datasets.txt
+```
 
 
+
+
+<br/>
+<br/>
 <br/>
 
 ## Files In this Repository

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ IMPORTANT NOTE. If you have launched VMs from Cacao, the ssh username is **<acce
 <br/>
 
 ### 5. Check Status of Kubernetes
+Connect to the master VM instance either through webshell or local IDE
+
 Kubernetes (k3s) have been pre-installed on each of the instances. 
 
 View nodes in your cluster

--- a/README.md
+++ b/README.md
@@ -374,6 +374,12 @@ There is a JS2 VM called `ofo-postgis` that hosts a postgis DB in docker. When w
 
 As of right now, the PostGIS server stores the following keys:
 
+| **Column**   | **Type** | **Description**  |
+|  --- | ----  | --- |
+|id | integer | unique identifier for each call of automate-metashape (not run) |
+| |  |
+
+
 * id: unique identifier for each call of automate-metashape (not run)
   
 * dataset-name: dataset running for the individual call of automate-metashape
@@ -394,9 +400,7 @@ During an automate-metashape run, we update an entry as the run progresses. We d
 
 * SSH into ofo-postgis `ssh exouser@<ip>`
 
-
 * Enter the Docker container running the PostGIS server `sudo docker exec -ti ofo-postgis bash`
-
 
 * Launch the PostgreSQL CLI as the intended user (grab from DB credentials) `psql -U postgres`
 
@@ -405,6 +409,7 @@ During an automate-metashape run, we update an entry as the run progresses. We d
 * Show the structure of a specific table (column names & data types) `\d automate_metashape`
 
 * View all data records for a specific table `select * from automate_metashape;`
+
 
 
 
@@ -420,7 +425,7 @@ During an automate-metashape run, we update an entry as the run progresses. We d
 
 ## Files In this Repository
 
-| File Name   | Purpose       |
+| File Name   | Purpose       | 
 |  --- | ----  |
 | argo-output-pv.yaml | Defines read-write PV for workflow output storage mounted at /ofo-share/argo-output |
 | argo-output-pvc.yaml | PVC bound to output volume | 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository contains [Argo Workflows](https://argoproj.github.io/workflows) used by the **Open Forest Observatory (OFO)**. It is being developed to run the [automate-metashape](https://github.com/open-forest-observatory/automate-metashape) pipeline simultaneously across multiple virtual machines on [Jetstream2 Cloud](https://jetstream-cloud.org/). This type of scaling enables OFO to process many photogrammetry projects simultaneously (instead of sequentially) and vastly reduce total processing time. Argo is meant to work on [Kubernetes](https://kubernetes.io/docs/concepts/overview/) which orchestrates containers (ie, automate-metashape in docker), scales the processing to multiple VMs, and balances the load between the VMs. 
 
+Outputs of the metashape runs are intended to be automatically funneled into a postGIS DB.
+
 ---
 
 <br/>

--- a/README.md
+++ b/README.md
@@ -294,7 +294,9 @@ argo submit -n argo workflow.yaml --watch \
 -p DATASET_LIST=datasets.txt
 ```
 
+### Monitor Argo Workflow
 
+![argo_workflow](https://github.com/user-attachments/assets/b2b1d6db-3543-4156-bd61-14ddc725b095)
 
 
 <br/>

--- a/README.md
+++ b/README.md
@@ -362,15 +362,10 @@ If you click on a specific job, it will show you lots of information of the proc
 <br/>
 <br/>
 
-## ofo-argo-utils
-There is a subfolder in ofo-argo called ofo-argo-utils. The intention of this is to contain code that helps with utility functions for automate-metashape (or in the future, any other data pipeline tasks). Right now, the main functionality is handling database logging (see more below). There is a GitHub actions workflow setup to automatically build an image for ofo-argo-utils on commits to ofo-argo. The purpose of this image is so that we can reference it in our Argo Workflows for reusability and portability. Here is an example of the image being used:
 
-<img width="422" alt="Screenshot 2025-06-20 at 4 50 00 PM" src="https://github.com/user-attachments/assets/a9a5ccf9-6197-4223-94b3-e1b140e928d1" />
+## Argo Workflow Logging in postGIS database
 
-<br/>
-
-## PostGIS Database
-There is a JS2 VM called `ofo-postgis` that hosts a postgis DB in docker. When we process drone imagery in Metashape, we want some information to be put into this postGIS database. This server has persistent storage, tied to a storage volume made in Jetstream.
+There is a JS2 VM called `ofo-postgis` that hosts a postgis DB in docker. When we process drone imagery in Metashape, we want workflow  information to be put into this postGIS database. This server has persistent storage, tied to a storage volume made in Jetstream.
 
 As of right now, the PostGIS server stores the following keys:
 
@@ -385,7 +380,30 @@ As of right now, the PostGIS server stores the following keys:
 | created_at | timestamp without time zone | creation time of entry in database |
 
 
+
+## ofo-argo-utils
+in the `ofo-argo-utils` directory: 
+
+a docker file to create an image with python and some libraries
+
+a requirements.txt the defines the python libraries to install on the docker image
+
+db_logger.py - python code to log argo workflow status into the postgis DM
+
+
+<br/>
+<br/>
+
+There is a subfolder in ofo-argo called ofo-argo-utils. The intention of this is to contain code that helps with utility functions for automate-metashape (or in the future, any other data pipeline tasks). Right now, the main functionality is handling database logging (see more below). There is a GitHub actions workflow setup to automatically build an image for ofo-argo-utils on commits to ofo-argo. The purpose of this image is so that we can reference it in our Argo Workflows for reusability and portability. Here is an example of the image being used:
+
 During an automate-metashape run, we update an entry as the run progresses. We do NOT add new rows to update the status. Moving forward, we might want to see if this is the best practice.
+
+
+<img width="422" alt="Screenshot 2025-06-20 at 4 50 00 PM" src="https://github.com/user-attachments/assets/a9a5ccf9-6197-4223-94b3-e1b140e928d1" />
+
+<br/>
+
+
 
 ### Access and Navigation of postgis DB  
 

--- a/README.md
+++ b/README.md
@@ -295,18 +295,9 @@ On the master instance terminal, type:
 
 ### 2. Run!!
 
-```
-argo submit -n argo workflow.yaml --watch \
--p AGISOFT_FLS=$AGISOFT_FLS \ ## specifies metashape license
--p RUN_FOLDER=gillan_test_0626 \  ## output folder name that is written to /ofo-share/argo-output
--p DATASET_LIST=datasets.txt  ## datasets to be processed as discussed in step 1 of Setup
-```
-<br/>
-<br/>
 
 ```
 argo submit -n argo workflow.yaml --watch \
--p CONFIG_FILE=/ofo-share/argo-output/config.yml \
 -p AGISOFT_FLS=$AGISOFT_FLS \
 -p RUN_FOLDER=gillan_test_test \
 -p DATASET_LIST=datasets.txt  

--- a/README.md
+++ b/README.md
@@ -298,9 +298,11 @@ On the master instance terminal, type:
 argo submit -n argo workflow.yaml --watch \
 -p AGISOFT_FLS=$AGISOFT_FLS \ ## specifies metashape license
 -p RUN_FOLDER=gillan_test_0620 \  ## output folder name that is written to /ofo-share/argo-output
--p DATASET_LIST=datasets.txt  ## datasets to be processed as discussed in [step 1 of Setup](./README.md#1-add-drone-imagery-data-to-ofo-shared-volume)
+-p DATASET_LIST=datasets.txt  ## datasets to be processed as discussed in [step 1 of Setup](#1-add-drone-imagery-data-to-ofo-shared-volume)
 ```
 <br/>
+
+[step 1 of Setup](#1-add-drone-imagery-data-to-ofo-shared-volume)
 
 ### Monitor Argo Workflow
 

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -60,7 +60,7 @@ spec:
         command: ["python3", "/app/python/metashape_workflow.py"]
         args: 
           - "--config_file"
-          - "{{workflow.parameters.CONFIG_FILE}}"
+          - "/data/{{workflow.parameters.CONFIG_FILE}}"
           - "--photo-path"
           - "/data/{{inputs.parameters.dataset-names}}"
           - "--project-path"

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -60,7 +60,7 @@ spec:
         command: ["python3", "/app/python/metashape_workflow.py"]
         args: 
           - "--config_file"
-          - "{{workflow.parameters.CONFIG_FILE | default \"/app/config/config-base.yml"}}"
+          - "{{workflow.parameters.CONFIG_FILE | default "/app/config/config-base.yml"}}"
           - "--photo-path"
           - "/data/{{inputs.parameters.dataset-names}}"
           - "--project-path"

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -6,11 +6,6 @@ spec:
   serviceAccountName: argo
   entrypoint: main
 
-  arguments:
-    parameters:
-      - name: config_path
-        description: "Path to Metashape config.yml"
-        default: "/app/config/config-base.yml"
   volumes:
   - name: data
     persistentVolumeClaim:
@@ -53,7 +48,7 @@ spec:
       inputs:
         parameters:
           - name: dataset-names
-          - name: config-path # ✅ Accept per-workflow config file path
+      
       container:
         image: ghcr.io/open-forest-observatory/automate-metashape
         volumeMounts:
@@ -64,8 +59,6 @@ spec:
           subPath: "{{workflow.parameters.RUN_FOLDER}}"
         command: ["python3", "/app/python/metashape_workflow.py"]
         args: 
-          - "--config_file"
-          - "{{inputs.parameters.config-path}}"  # ✅ Used in args
           - "--photo-path"
           - "/data/{{inputs.parameters.dataset-names}}"
           - "--project-path"

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -6,6 +6,17 @@ spec:
   serviceAccountName: argo
   entrypoint: main
 
+  arguments:
+    parameters:
+      - name: CONFIG_FILE
+        default: "config.yml"
+      - name: RUN_FOLDER
+        default: "default-run"
+      - name: DATASET_LIST
+        default: "datasets.txt"
+      - name: AGISOFT_FLS
+        default: ""
+        
   volumes:
   - name: data
     persistentVolumeClaim:
@@ -25,6 +36,8 @@ spec:
               parameters:
                 - name: dataset-names
                   value: "{{item}}"
+                - name: config-file
+                  value: "{{workflow.parameters.CONFIG_FILE}}"
             withParam: "{{steps.determine-datasets.outputs.result}}"
     
     # use subPath argument to mount dataset list argument (in /ofo-share/results/datasets.txt for now)
@@ -48,6 +61,7 @@ spec:
       inputs:
         parameters:
           - name: dataset-names
+          - name: config-file
       
       container:
         image: ghcr.io/open-forest-observatory/automate-metashape
@@ -60,7 +74,7 @@ spec:
         command: ["python3", "/app/python/metashape_workflow.py"]
         args: 
           - "--config_file"
-          - "/results/config.yml"
+          - "/results/{{inputs.parameters.config-file}}"
           - "--photo-path"
           - "/data/{{inputs.parameters.dataset-names}}"
           - "--project-path"

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -60,7 +60,7 @@ spec:
         command: ["python3", "/app/python/metashape_workflow.py"]
         args: 
           - "--config_file"
-          - "{{workflow.parameters.CONFIG_PATH}}"
+          - "{{workflow.parameters.CONFIG_FILE | default \"/app/config/config-base.yml"}}"
           - "--photo-path"
           - "/data/{{inputs.parameters.dataset-names}}"
           - "--project-path"

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -60,7 +60,7 @@ spec:
         command: ["python3", "/app/python/metashape_workflow.py"]
         args: 
           - "--config_file"
-          - "/data/{{workflow.parameters.CONFIG_FILE}}"
+          - "/results/{{workflow.parameters.CONFIG_FILE}}"
           - "--photo-path"
           - "/data/{{inputs.parameters.dataset-names}}"
           - "--project-path"

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -67,7 +67,6 @@ spec:
           - "/results/{{workflow.parameters.RUN_FOLDER}}/project"
           - "--output-path"
           - "/results/{{workflow.parameters.RUN_FOLDER}}/output"
-          - "/results/output"
           - "--run-name"
           - "test-run-{{inputs.parameters.dataset-names}}"
         env:

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -5,11 +5,12 @@ metadata:
 spec:
   serviceAccountName: argo
   entrypoint: main
-  # ✅ Added parameter for runtime config path override
-  parameters:
-    - name: config_path
-      description: "Path to Metashape config.yml"
-      default: "/app/config/config-base.yml"
+
+  arguments:
+    parameters:
+      - name: config_path
+        description: "Path to Metashape config.yml"
+        default: "/app/config/config-base.yml"
   volumes:
   - name: data
     persistentVolumeClaim:

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -56,16 +56,17 @@ spec:
           mountPath: /data
         - name: results
           mountPath: /results
-          subPath: "{{workflow.parameters.RUN_FOLDER}}"
+          #subPath: "{{workflow.parameters.RUN_FOLDER}}"
         command: ["python3", "/app/python/metashape_workflow.py"]
         args: 
           - "--config_file"
-          - "/results/{{workflow.parameters.CONFIG_FILE}}"
+          - "/results/config.yml"
           - "--photo-path"
           - "/data/{{inputs.parameters.dataset-names}}"
           - "--project-path"
-          - "/results/project"
+          - "/results/{{workflow.parameters.RUN_FOLDER}}/project"
           - "--output-path"
+          - "/results/{{workflow.parameters.RUN_FOLDER}}/output"
           - "/results/output"
           - "--run-name"
           - "test-run-{{inputs.parameters.dataset-names}}"

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -62,6 +62,21 @@ spec:
         parameters:
           - name: dataset-names
           - name: config-file
+
+      metadata:
+        labels:
+          workload-type: metashape-job  # arbitrary, but used for spreading
+
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: workload-type
+                    operator: In
+                    values:
+                      - metashape-job
+              topologyKey: "kubernetes.io/hostname"
       
       container:
         image: ghcr.io/open-forest-observatory/automate-metashape

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -62,11 +62,11 @@ spec:
         parameters:
           - name: dataset-names
           - name: config-file
-
+      #the following 'metadata' and 'affinity' language is about ensuring one metashape project on one VM (unless more projects than nodes)
       metadata:
         labels:
           workload-type: metashape-job  # arbitrary, but used for spreading
-
+      
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -60,7 +60,7 @@ spec:
         command: ["python3", "/app/python/metashape_workflow.py"]
         args: 
           - "--config_file"
-          - "{{workflow.parameters.CONFIG_FILE | default "/app/config/config-base.yml"}}"
+          - "{{if workflow.parameters.CONFIG_FILE}}{{workflow.parameters.CONFIG_FILE}}{{else}}/app/config/config-base.yml{{end}}"
           - "--photo-path"
           - "/data/{{inputs.parameters.dataset-names}}"
           - "--project-path"

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -78,9 +78,9 @@ spec:
           - "--photo-path"
           - "/data/{{inputs.parameters.dataset-names}}"
           - "--project-path"
-          - "/results/{{workflow.parameters.RUN_FOLDER}}/project"
+          - "/results/{{workflow.parameters.RUN_FOLDER}}/{{inputs.parameters.dataset-names}}/project"
           - "--output-path"
-          - "/results/{{workflow.parameters.RUN_FOLDER}}/output"
+          - "/results/{{workflow.parameters.RUN_FOLDER}}/{{inputs.parameters.dataset-names}}/output"
           - "--run-name"
           - "test-run-{{inputs.parameters.dataset-names}}"
         env:

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -59,6 +59,8 @@ spec:
           subPath: "{{workflow.parameters.RUN_FOLDER}}"
         command: ["python3", "/app/python/metashape_workflow.py"]
         args: 
+          - "--config_file"
+          - "{{workflow.parameters.CONFIG_PATH}}"
           - "--photo-path"
           - "/data/{{inputs.parameters.dataset-names}}"
           - "--project-path"

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -5,6 +5,11 @@ metadata:
 spec:
   serviceAccountName: argo
   entrypoint: main
+  # ✅ Added parameter for runtime config path override
+  parameters:
+    - name: config_path
+      description: "Path to Metashape config.yml"
+      default: "/app/config/config-base.yml"
   volumes:
   - name: data
     persistentVolumeClaim:
@@ -47,6 +52,7 @@ spec:
       inputs:
         parameters:
           - name: dataset-names
+          - name: config-path # ✅ Accept per-workflow config file path
       container:
         image: ghcr.io/open-forest-observatory/automate-metashape
         volumeMounts:
@@ -57,6 +63,8 @@ spec:
           subPath: "{{workflow.parameters.RUN_FOLDER}}"
         command: ["python3", "/app/python/metashape_workflow.py"]
         args: 
+          - "--config_file"
+          - "{{inputs.parameters.config-path}}"  # ✅ Used in args
           - "--photo-path"
           - "/data/{{inputs.parameters.dataset-names}}"
           - "--project-path"

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -60,7 +60,7 @@ spec:
         command: ["python3", "/app/python/metashape_workflow.py"]
         args: 
           - "--config_file"
-          - "{{if workflow.parameters.CONFIG_FILE}}{{workflow.parameters.CONFIG_FILE}}{{else}}/app/config/config-base.yml{{end}}"
+          - "{{workflow.parameters.CONFIG_FILE}}"
           - "--photo-path"
           - "/data/{{inputs.parameters.dataset-names}}"
           - "--project-path"


### PR DESCRIPTION
The argo workflow has been updated: 

- Metashape parameters can be specified in config.yml in `/ofo-share/argo-output`
- Processing jobs are load balanced across VMs (one dataset per VM)
- Should work with GPUs
- Metashape outputs are written in an organized directory structure
- workflow.yml was significantly adjusted to accomplish these tasks
- Clear instructions in readme to run entire workflow