### PR TITLE
jgillan/config_list

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,19 +40,15 @@ Here is a schematic of the `/ofo-share` directory.
 ├── argo-input/
 │   ├──datasets/
 │   │   ├──dataset_1/
-│           ├── image_01.jpg
-│           └── image_02.jpg
+│   │   │   ├── image_01.jpg
+│   │   │   └── image_02.jpg
 │   │   ├──dataset_2/
-│           ├── image_01.jpg
-│           └── image_02.jpg
-│   ├── config.yml
-│   ├── datasets.txt
-│   ├── benchmarking-greasewood/
-│   │   ├── image_01.jpg
-│   │   └── image_02.jpg
-│   └── benchmarking-swetnam-house/
-│       ├── image_01.jpg
-│       └── image_02.jpg
+│   │       ├── image_01.jpg
+│   │       └── image_02.jpg
+│   ├── configs/
+│   │   ├──config_1.yml
+│   │   └──config_2.yml
+│   ├── config_list.txt
 └── argo-output/
     └── <RUN_FOLDER>/
         ├── benchmarking-greasewood/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository contains [Argo Workflows](https://argoproj.github.io/workflows) used by the **Open Forest Observatory (OFO)**. It is being developed to run the [automate-metashape](https://github.com/open-forest-observatory/automate-metashape) pipeline simultaneously across multiple virtual machines on [Jetstream2 Cloud](https://jetstream-cloud.org/). This type of scaling enables OFO to process many photogrammetry projects simultaneously with a single run command. Argo is meant to work on [Kubernetes](https://kubernetes.io/docs/concepts/overview/) which orchestrates containers (ie, automate-metashape in docker), scales the processing to multiple VMs, and balances the load between the VMs. 
 
+The current setup includes a master VM instance (orchestrator) and multiple worker instances (processes metashape projects). The worker instances are configured to process one metashape project at a time. If there are more metashape projects than worker instances, the projects will be queued until a worker is free. GPU worker instances will greatly increase the speed of processing.  
+
 
 <br/>
 
@@ -30,12 +32,19 @@ This repository contains [Argo Workflows](https://argoproj.github.io/workflows) 
 
 ### 1. Inputs
 
-Inputs to the metashape argo workflow include **1.** drone imagery datasets consisting of jpegs, **2.** a list (datasets.txt) of the dataset names to be processed, and **3.** a metashape config.yml. All of these inputs need to be on the `ofo-share` volume. This volume will be automatically mounted to any VM built from `ofo-dev` image using [Exosphere interface](https://jetstream2.exosphere.app/exosphere/). The volume is mounted at `/ofo-share` of the VM.
+Inputs to the metashape argo workflow include **1.** drone imagery datasets consisting of jpegs, **2.** a list of the names of metashape configuration files (config_list.txt), and **3.** the metashape config.ymls. All of these inputs need to be on the `ofo-share` volume. This volume will be automatically mounted to any VM built from `ofo-dev` image using [Exosphere interface](https://jetstream2.exosphere.app/exosphere/). The volume is mounted at `/ofo-share` of the VM.
 
 Here is a schematic of the `/ofo-share` directory. 
 ```bash
 /ofo-share/
 ├── argo-input/
+│   ├──datasets/
+│   │   ├──dataset_1/
+│           ├── image_01.jpg
+│           └── image_02.jpg
+│   │   ├──dataset_2/
+│           ├── image_01.jpg
+│           └── image_02.jpg
 │   ├── config.yml
 │   ├── datasets.txt
 │   ├── benchmarking-greasewood/

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ To add new drone imagery datasets to be processed using Argo, transfer files fro
 
 #### b. Specify Metashape Parameters
 
-Metashape processing parameters are specified in [config.yml](https://github.com/open-forest-observatory/automate-metashape/blob/main/config/config-base.yml) files which need to be located at `/ofo-share/argo-input/configs`. Every dataset to be processed needs to have it's own standalone config.yml file. These config files can be named however you want. 
+Metashape processing parameters are specified in [config.yml](https://github.com/open-forest-observatory/automate-metashape/blob/main/config/config-base.yml) files which need to be located at `/ofo-share/argo-input/configs`. Every dataset to be processed needs to have it's own standalone config.yml file. These config files can be named however you want (e.g., `config_dataset_1.yml`)
 
 Within each metashape config.yml file, you need to specify 'photo_path' which is the location of the drone imagery dataset to be processed. This path refers to the location of the images inside a docker container. For example, if your drone images were uploaded to `/ofo-share/argo-input/datasets/dataset_1`, then the 'photo_path' should be written as `/data/argo-input/datasets/dataset_1`
 
@@ -92,9 +92,9 @@ Additionally we use a text file, for example `config_list.txt`, to tell the Argo
 For example:
 
 ```
-benchmarking-swetnam-house
-benchmarking-greasewood
-benchmarking-emerald-subset
+config_dataset_1
+config_dataset_2
+config_dataset_2
 ```  
 
 You can create your own config_list.txt file and name it whatever you want as long as it is kept in this directory `/ofo-share/argo-input`. 

--- a/README.md
+++ b/README.md
@@ -73,20 +73,22 @@ To add new drone imagery datasets to be processed using Argo, transfer files fro
 `scp -r <local/directory/drone_image_dataset/> exouser@<vm.ip.address>:/ofo-share/argo-input/datasets`
 
 
-
-
-<br/>
-
-#### b. Specify which datasets to process in Argo
-The file `/ofo-share/argo-input/datasets.txt` contains of list of the named datasets to process in argo. 
-
-
 <br/>
 <br/>
 
 #### c. Specify Metashape Parameters
 
-All metashape parameters are specified in a config.yml file which is located at `/ofo-share/argo-input`. You can create your own config yml as long as it is kept in this directory. The exact file (e.g., config2.yml or projectname_config.yml) will be specified as a parameter in the argo run command later in this workflow. 
+Metashape processing parameters are specified in config.yml files which need to be located at `/ofo-share/argo-input/configs`. Every dataset to be processed needs to have it's own standalone config.yml file. These config files can be named however you want. 
+
+Additionally we use a text file, for example `config_list.txt`, to tell the Argo workflow which config files should be processed in the current run. This text file should list each of the names of the config.yml files you want to process. 
+
+```
+benchmarking-swetnam-house
+benchmarking-greasewood
+benchmarking-emerald-subset
+```  
+
+You can create your own config yml as long as it is kept in this directory. The exact file (e.g., config2.yml or projectname_config.yml) will be specified as a parameter in the argo run command later in this workflow. 
 
 <br/>
 <br/>

--- a/README.md
+++ b/README.md
@@ -38,27 +38,27 @@ Here is a schematic of the `/ofo-share` directory.
 ```bash
 /ofo-share/
 ├── argo-input/
-│   ├──datasets/
+│   ├── datasets/
 │   │   ├──dataset_1/
 │   │   │   ├── image_01.jpg
 │   │   │   └── image_02.jpg
-│   │   ├──dataset_2/
+│   │   └──dataset_2/
 │   │       ├── image_01.jpg
 │   │       └── image_02.jpg
 │   ├── configs/
 │   │   ├──config_1.yml
 │   │   └──config_2.yml
-│   ├── config_list.txt
+│   └── config_list.txt
 └── argo-output/
     └── <RUN_FOLDER>/
-        ├── benchmarking-greasewood/
+        ├── dataset_1/
         │   ├── output/
         │   │   ├── orthomosaic.tif
         │   │   ├── dsm.tif
         │   │   └── point-cloud.laz
         │   └── project/
         │       └── metashape_project.psx
-        └── benchmarking-swetnam-house/
+        └── dataset_2/
             ├── output/
             │   ├── orthomosaic.tif
             │   ├── dsm.tif

--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ Here is a schematic of the `/ofo-share` directory.
 ```
 
 #### a. Add drone imagery to OFO shared volume
-To add new drone imagery datasets to be processed using Argo, transfer files from your local machine to the `/ofo-share` volume.
+To add new drone imagery datasets to be processed using Argo, transfer files from your local machine to the `/ofo-share` volume. Put the drone imagery projects to be processed in there own directory in `/ofo-share/argo-input/datasets`. 
 
-`scp -r <local/directory/drone_image_dataset> exouser@<vm.ip.address>:/ofo-share/argo-input`
+`scp -r <local/directory/drone_image_dataset/> exouser@<vm.ip.address>:/ofo-share/argo-input/datasets`
 
-Put the drone imagery projects to be processed in it's own directory in `/ofo-share/argo-input`. For example, there are 4 testing datasets already in the directory called `benchmarking-emerald-subset`, `benchmarking-emerald-full`, `benchmarking-swetnam-house`, `benchmarking-greasewood`
+
 
 
 <br/>

--- a/README.md
+++ b/README.md
@@ -370,10 +370,9 @@ This variable will only last during the terminal session and will have to be re-
 
 ```
 argo submit -n argo workflow.yaml --watch \
--p CONFIG_FILE=config2.yml \
+-p CONFIG_LIST=config_list.txt \
 -p AGISOFT_FLS=$AGISOFT_FLS \
 -p RUN_FOLDER=gillan_june27 \
--p DATASET_LIST=datasets.txt \
 -p DB_PASSWORD=<password> \
 -p DB_HOST=<vm_ip_address> \
 -p DB_NAME=<db_name> \
@@ -381,13 +380,11 @@ argo submit -n argo workflow.yaml --watch \
  
 ```
 
-CONFIG_FILE is the configuration yml which specifies the metashape parameters which should be located in `/ofo-share/argo-output`
+CONFIG_LIST is a text file that lists each of the metashape parameter config files to be processed which should be located in `/ofo-share/argo-output`
 
 AGISOFT_FLS is the ip address of the metashape license server
 
 RUN_FOLDER is what you want to name the parent directory of your output
-
-DATSET_LIST is the txt file where you specified the names of the datasets you want to process located at `/ofo-share/argo-output`
 
 The rest of the 'DB' parameters are for logging argo status in a postGIS database. These are not public credentials. Authorized users can find them [here](https://docs.google.com/document/d/155AP0P3jkVa-yT53a-QLp7vBAfjRa78gdST1Dfb4fls/edit?tab=t.0).
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Here is a schematic of the `/ofo-share` directory.
 │   │       ├── image_01.jpg
 │   │       └── image_02.jpg
 │   ├── configs/
-│   │   ├──config_1.yml
-│   │   └──config_2.yml
+│   │   ├──config_dataset_1.yml
+│   │   └──config_dataset_2.yml
 │   └── config_list.txt
 └── argo-output/
     └── <RUN_FOLDER>/

--- a/README.md
+++ b/README.md
@@ -493,24 +493,27 @@ The metashape outputs will be written to `/ofo-share/argo-outputs/<RUN_FOLDER>`.
 ```bash
 /ofo-share/
 ├── argo-input/
-│   ├── config.yml
-│   ├── datasets.txt
-│   ├── benchmarking-greasewood/
-│   │   ├── image_01.jpg
-│   │   └── image_02.jpg
-│   └── benchmarking-swetnam-house/
-│       ├── image_01.jpg
-│       └── image_02.jpg
+│   ├── datasets/
+│   │   ├──dataset_1/
+│   │   │   ├── image_01.jpg
+│   │   │   └── image_02.jpg
+│   │   └──dataset_2/
+│   │       ├── image_01.jpg
+│   │       └── image_02.jpg
+│   ├── configs/
+│   │   ├──config_dataset_1.yml
+│   │   └──config_dataset_2.yml
+│   └── config_list.txt
 └── argo-output/
     └── <RUN_FOLDER>/
-        ├── benchmarking-greasewood/
+        ├── dataset_1/
         │   ├── output/
         │   │   ├── orthomosaic.tif
         │   │   ├── dsm.tif
         │   │   └── point-cloud.laz
         │   └── project/
         │       └── metashape_project.psx
-        └── benchmarking-swetnam-house/
+        └── dataset_2/
             ├── output/
             │   ├── orthomosaic.tif
             │   ├── dsm.tif
@@ -518,6 +521,7 @@ The metashape outputs will be written to `/ofo-share/argo-outputs/<RUN_FOLDER>`.
             └── project/
                 └── metashape_project.psx
 ```
+
 
 
 
@@ -546,32 +550,7 @@ The DB is running in a docker container (`postgis/postgis`). The DB storage is a
 
 <br/>
 
-View all running and stopped containers
-
-`docker ps -a`
-
-<br/>
-
-Stop a running container
-
-`docker stop <container_id>`
-
-<br/>
-
-Remove container
-
-`docker rm <container_id>`
-
-<br/>
-
-
-Run the docker container DB
-
-```
-sudo docker run --name ofo-postgis   -e POSTGRES_PASSWORD=ujJ1tsY9OizN0IpOgl1mY1cQGvgja3SI   -p 5432:5432   -v /media/volume/ofo-postgis/data:/var/lib/postgresql/data  -d postgis/postgis
-```
-<br/>
-<br/>
+#### Steps to View the Logged Results
 
 Enter the Docker container running the PostGIS server `sudo docker exec -ti ofo-postgis bash`
 
@@ -607,6 +586,7 @@ Currently, the PostGIS server stores the following keys in the `automate_metasha
 <br/>
 
 View all data records for a specific table `select * from automate_metashape ORDER BY id DESC;`
+
 <img width="1000" height="183" alt="sql_query" src="https://github.com/user-attachments/assets/cba4532a-21de-4c35-8b2d-635eec326ef7" />
 
 <br/>
@@ -616,6 +596,39 @@ Exit out of psql command-line `\q`
 <br/>
 
 Exit out of container `exit`
+
+
+<br/>
+<br/>
+
+#### Other useful commands
+
+View all running and stopped containers
+
+`docker ps -a`
+
+<br/>
+
+Stop a running container
+
+`docker stop <container_id>`
+
+<br/>
+
+Remove container
+
+`docker rm <container_id>`
+
+<br/>
+
+
+Run the docker container DB
+
+```
+sudo docker run --name ofo-postgis   -e POSTGRES_PASSWORD=ujJ1tsY9OizN0IpOgl1mY1cQGvgja3SI   -p 5432:5432   -v /media/volume/ofo-postgis/data:/var/lib/postgresql/data  -d postgis/postgis
+```
+
+
 
 <br/>
 <br/>

--- a/README.md
+++ b/README.md
@@ -74,13 +74,22 @@ To add new drone imagery datasets to be processed using Argo, transfer files fro
 
 
 <br/>
+
+#### b. Specify Metashape Parameters
+
+Metashape processing parameters are specified in [config.yml](https://github.com/open-forest-observatory/automate-metashape/blob/main/config/config-base.yml) files which need to be located at `/ofo-share/argo-input/configs`. Every dataset to be processed needs to have it's own standalone config.yml file. These config files can be named however you want. 
+
+Within each metashape config.yml file, you need to specify 'photo_path' which is the location of the drone imagery dataset to be processed. This path refers to the location of the images inside a docker container. For example, if your drone images were uploaded to `/ofo-share/argo-input/datasets/dataset_1`, then the 'photo_path' should be written as `/data/argo-input/datasets/dataset_1`
+
+The 'output_path', 'project_path', and 'run_name' are handled in the argo workflow. Please do not specify them in the metashape config.yml.
+
 <br/>
 
-#### c. Specify Metashape Parameters
+#### c. Config List
 
-Metashape processing parameters are specified in config.yml files which need to be located at `/ofo-share/argo-input/configs`. Every dataset to be processed needs to have it's own standalone config.yml file. These config files can be named however you want. 
+Additionally we use a text file, for example `config_list.txt`, to tell the Argo workflow which config files should be processed in the current run. This text file should list each of the names of the config.yml files you want to process. One config file name per line. Please remove the file extension .yml
 
-Additionally we use a text file, for example `config_list.txt`, to tell the Argo workflow which config files should be processed in the current run. This text file should list each of the names of the config.yml files you want to process. 
+For example:
 
 ```
 benchmarking-swetnam-house
@@ -88,7 +97,7 @@ benchmarking-greasewood
 benchmarking-emerald-subset
 ```  
 
-You can create your own config yml as long as it is kept in this directory. The exact file (e.g., config2.yml or projectname_config.yml) will be specified as a parameter in the argo run command later in this workflow. 
+You can create your own config_list.txt file and name it whatever you want as long as it is kept in this directory `/ofo-share/argo-input`. 
 
 <br/>
 <br/>

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -6,8 +6,6 @@ spec:
   serviceAccountName: argo
   entrypoint: main
 
-  # A list of input parameters available to the workflow at runtime. 
-  # These parameters can be referenced throughout the workflow templates using {{workflow.parameters.<name>}}.
   arguments:
     parameters:
       - name: CONFIG_LIST
@@ -25,61 +23,52 @@ spec:
       - name: DB_PASSWORD
         default: ""
 
-  # Defining where to read raw drone imagery data and write out imagery products to `/ofo-share`
   volumes:
-  - name: data
-    persistentVolumeClaim:
-      claimName: ofo-share-nfs-pvc
-  - name: results
-    persistentVolumeClaim:
-      claimName: argo-output-nfs-pvc
+    - name: data
+      persistentVolumeClaim:
+        claimName: ofo-share-nfs-pvc
+    - name: results
+      persistentVolumeClaim:
+        claimName: argo-output-nfs-pvc
 
   templates:
-    # the 'main' template defines the order of high-level steps to be completed in the workflow. 
-    # the 'process-datasets' step has a looping directive (withParam) which goes through each dataset name and processes it. 
+
     - name: main
       steps:
-        - - name: determine-configs
-            template: determine-configs
-        - - name: log-configs-to-db
-            template: log-configs-to-db
+        - - name: determine-datasets
+            template: determine-datasets
+        - - name: log-datasets-to-db
+            template: log-datasets-to-db
             arguments:
               parameters:
-                - name: configs
-                  value: "{{steps.determine-configs.outputs.result}}"
-        - - name: process-configs
-            template: process-config-workflow
+                - name: datasets
+                  value: "{{steps.determine-datasets.outputs.result}}"
+        - - name: process-datasets
+            template: process-dataset-workflow
             arguments:
               parameters:
-                - name: config-file
+                - name: dataset-name
                   value: "{{item}}"
-            withParam: "{{steps.determine-configs.outputs.result}}"
+            withParam: "{{steps.determine-datasets.outputs.result}}"
 
-    ## here we define what the main steps actually do 
-    
-    # Use containerized python to parse through the list of datasets as specified from runtime parameter 'DATASET_LIST'
-    # outputs a json of dataset names that is passed to the next steps
-    - name: determine-configs
+    - name: determine-datasets
       script:
         image: python:3.9
         volumeMounts:
-        - name: data
-          mountPath: /input
-          subPath: "argo-input/{{workflow.parameters.CONFIG_LIST}}"
+          - name: data
+            mountPath: /input
+            subPath: "argo-input/{{workflow.parameters.CONFIG_LIST}}"
         command: ["python3"]
         source: |
-          import json
-          import sys
-          file_path = "/input"
-          with open(file_path, "r") as f:
-            json.dump([line.strip() for line in f], sys.stdout)
+          import json, sys
+          with open("/input", "r") as f:
+              datasets = [line.strip() for line in f if line.strip()]
+              json.dump(datasets, sys.stdout)
 
-    # launches a docker container which contains our custom py script to log the dataset names into a postgis database
-    # takes the json list of dataset names (from the 'determine datasets' step)
-    - name: log-configs-to-db
+    - name: log-datasets-to-db
       inputs:
         parameters:
-          - name: configs
+          - name: datasets
       container:
         image: ghcr.io/open-forest-observatory/ofo-argo-utils:latest
         command: ["python", "/app/db_logger.py"]
@@ -87,8 +76,8 @@ spec:
           - "log-initial"
           - "--workflow-id"
           - "{{workflow.name}}"
-          - "--configs-json"
-          - "{{inputs.parameters.configs}}"
+          - "--datasets-json"
+          - "{{inputs.parameters.datasets}}"
         env:
           - name: DB_HOST
             value: "{{workflow.parameters.DB_HOST}}"
@@ -98,27 +87,26 @@ spec:
             value: "{{workflow.parameters.DB_USER}}"
           - name: DB_PASSWORD
             value: "{{workflow.parameters.DB_PASSWORD}}"
-    
-    # High-level order of steps in the workflow. Each step will be defined later.      
-    - name: process-config-workflow
+
+    - name: process-dataset-workflow
       inputs:
         parameters:
-          - name: config-file  
+          - name: dataset-name
       steps:
         - - name: log-start
-            template: log-config-start
+            template: log-dataset-start
             arguments:
               parameters:
-                - name: config-file
-                  value: "{{inputs.parameters.config-file}}"
+                - name: dataset-name
+                  value: "{{inputs.parameters.dataset-name}}"
         - - name: run-processing
             template: run-automate-metashape
             arguments:
               parameters:
-                - name: config-file
-                  value: "{{inputs.parameters.config-file}}" 
+                - name: dataset-name
+                  value: "{{inputs.parameters.dataset-name}}"
             continueOn:
-              failed: true  # EVEN IF this step fails, keep the workflow running (needed to log failure in DB later)
+              failed: true
         - - name: determine-success
             template: evaluate-success
             arguments:
@@ -126,21 +114,18 @@ spec:
                 - name: step-status
                   value: "{{steps.run-processing.status}}"
         - - name: log-completion
-            template: log-config-completion
+            template: log-dataset-completion
             arguments:
               parameters:
-                - name: config-file
-                  value: "{{inputs.parameters.config-file}}"
+                - name: dataset-name
+                  value: "{{inputs.parameters.dataset-name}}"
                 - name: success
-                  value: "{{steps.determine-success.outputs.result}}"      
+                  value: "{{steps.determine-success.outputs.result}}"
 
-    ## Here we define what each step does
-    
-    # use our custom containerized db_logger.py to log 'processing' in the postgis DB
-    - name: log-config-start
+    - name: log-dataset-start
       inputs:
         parameters:
-          - name: config-file
+          - name: dataset-name
       container:
         image: ghcr.io/open-forest-observatory/ofo-argo-utils:latest
         command: ["python", "/app/db_logger.py"]
@@ -148,8 +133,8 @@ spec:
           - "log-start"
           - "--workflow-id"
           - "{{workflow.name}}"
-          - "--config"
-          - "{{inputs.parameters.config-file}}"
+          - "--dataset"
+          - "{{inputs.parameters.dataset-name}}"
         env:
           - name: DB_HOST
             value: "{{workflow.parameters.DB_HOST}}"
@@ -159,12 +144,11 @@ spec:
             value: "{{workflow.parameters.DB_USER}}"
           - name: DB_PASSWORD
             value: "{{workflow.parameters.DB_PASSWORD}}"
-    
-    # use our custom containerized db_logger.py to log 'completed' or 'failed' in the postgis DB
-    - name: log-config-completion
+
+    - name: log-dataset-completion
       inputs:
         parameters:
-          - name: config-file
+          - name: dataset-name
           - name: success
       container:
         image: ghcr.io/open-forest-observatory/ofo-argo-utils:latest
@@ -173,8 +157,8 @@ spec:
           - "log-completion"
           - "--workflow-id"
           - "{{workflow.name}}"
-          - "--config"
-          - "{{inputs.parameters.config-file}}"
+          - "--dataset"
+          - "{{inputs.parameters.dataset-name}}"
           - "--success"
           - "{{inputs.parameters.success}}"
         env:
@@ -186,8 +170,7 @@ spec:
             value: "{{workflow.parameters.DB_USER}}"
           - name: DB_PASSWORD
             value: "{{workflow.parameters.DB_PASSWORD}}"
-    
-    # Script to determine success of failure of step
+
     - name: evaluate-success
       inputs:
         parameters:
@@ -200,16 +183,13 @@ spec:
           status = "{{inputs.parameters.step-status}}"
           sys.stdout.write("true" if status == "Succeeded" else "false")
 
-    # Defining how to process each dataset name      
     - name: run-automate-metashape
       inputs:
         parameters:
-          - name: config-file
-      # the following 'metadata' and 'affinity' language is about ensuring one metashape project on one VM
+          - name: dataset-name
       metadata:
         labels:
-          workload-type: metashape-job  # arbitrary, but used for pod spreading
-      
+          workload-type: metashape-job
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -220,27 +200,23 @@ spec:
                     values:
                       - metashape-job
               topologyKey: "kubernetes.io/hostname"
-
-      # Use docker automate-metashape to do photogrammetry
       container:
         image: ghcr.io/open-forest-observatory/automate-metashape
         volumeMounts:
-        - name: data
-          mountPath: /data
-        - name: results
-          mountPath: /results
+          - name: data
+            mountPath: /data
+          - name: results
+            mountPath: /results
         command: ["python3", "/app/python/metashape_workflow.py"]
-        args: 
+        args:
           - "--config_file"
-          - "/data/argo-input/configs/{{inputs.parameters.config-file}}"
-          #- "--photo-path"
-          #- "/data/argo-input/{{inputs.parameters.dataset-names}}"
+          - "/data/argo-input/configs/{{inputs.parameters.dataset-name}}"
           - "--project-path"
-          - "/results/{{workflow.parameters.RUN_FOLDER}}/{{inputs.parameters.config-file}}/project"
+          - "/results/{{workflow.parameters.RUN_FOLDER}}/{{inputs.parameters.dataset-name}}/project"
           - "--output-path"
-          - "/results/{{workflow.parameters.RUN_FOLDER}}/{{inputs.parameters.config-file}}/output"
+          - "/results/{{workflow.parameters.RUN_FOLDER}}/{{inputs.parameters.dataset-name}}/output"
           - "--run-name"
-          - "{{inputs.parameters.config-file}}"
+          - "{{inputs.parameters.dataset-name}}"
         env:
           - name: AGISOFT_FLS
             value: "{{workflow.parameters.AGISOFT_FLS}}"

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -6,6 +6,8 @@ spec:
   serviceAccountName: argo
   entrypoint: main
 
+  # A list of input parameters available to the workflow at runtime. 
+  # These parameters can be referenced throughout the workflow templates using {{workflow.parameters.<name>}}
   arguments:
     parameters:
       - name: CONFIG_LIST
@@ -23,6 +25,7 @@ spec:
       - name: DB_PASSWORD
         default: ""
 
+  # Defining where to read raw drone imagery data and write out imagery products to `/ofo-share`
   volumes:
     - name: data
       persistentVolumeClaim:
@@ -32,7 +35,8 @@ spec:
         claimName: argo-output-nfs-pvc
 
   templates:
-
+    # the 'main' template defines the order of high-level steps to be completed in the workflow. 
+    # the 'process-datasets' step has a looping directive (withParam) which goes through each dataset name and processes it.
     - name: main
       steps:
         - - name: determine-datasets
@@ -51,6 +55,10 @@ spec:
                   value: "{{item}}"
             withParam: "{{steps.determine-datasets.outputs.result}}"
 
+## Here we define what the main steps actually do 
+
+   # Use containerized python to parse through the list of datasets as specified from runtime parameter 'CONFIG_LIST'
+    # outputs a json of dataset names that is passed to the next steps
     - name: determine-datasets
       script:
         image: python:3.9
@@ -64,7 +72,9 @@ spec:
           with open("/input", "r") as f:
               datasets = [line.strip() for line in f if line.strip()]
               json.dump(datasets, sys.stdout)
-
+              
+    # launches a docker container which contains our custom py script to log the dataset names into a postgis database
+    # takes the json list of dataset names (from the 'determine datasets' step)
     - name: log-datasets-to-db
       inputs:
         parameters:
@@ -87,7 +97,8 @@ spec:
             value: "{{workflow.parameters.DB_USER}}"
           - name: DB_PASSWORD
             value: "{{workflow.parameters.DB_PASSWORD}}"
-
+            
+    # High-level order of steps in the 'process-dataset-workflow' step. Each step will be defined later.
     - name: process-dataset-workflow
       inputs:
         parameters:
@@ -121,7 +132,10 @@ spec:
                   value: "{{inputs.parameters.dataset-name}}"
                 - name: success
                   value: "{{steps.determine-success.outputs.result}}"
-
+                  
+    ## Here we define what each step does in 'process-dataset-workflow' step
+    
+    # use our custom containerized db_logger.py to log 'processing' in the postgis DB
     - name: log-dataset-start
       inputs:
         parameters:
@@ -144,7 +158,8 @@ spec:
             value: "{{workflow.parameters.DB_USER}}"
           - name: DB_PASSWORD
             value: "{{workflow.parameters.DB_PASSWORD}}"
-
+            
+    # use our custom containerized db_logger.py to log 'completed' or 'failed' in the postgis DB
     - name: log-dataset-completion
       inputs:
         parameters:
@@ -170,7 +185,8 @@ spec:
             value: "{{workflow.parameters.DB_USER}}"
           - name: DB_PASSWORD
             value: "{{workflow.parameters.DB_PASSWORD}}"
-
+            
+    # Script to determine success of failure of step
     - name: evaluate-success
       inputs:
         parameters:
@@ -182,11 +198,13 @@ spec:
           import sys
           status = "{{inputs.parameters.step-status}}"
           sys.stdout.write("true" if status == "Succeeded" else "false")
-
+          
+    # Defining how to process each dataset name
     - name: run-automate-metashape
       inputs:
         parameters:
           - name: dataset-name
+      # the following 'metadata' and 'affinity' language is about ensuring one metashape project on one VM
       metadata:
         labels:
           workload-type: metashape-job
@@ -200,6 +218,7 @@ spec:
                     values:
                       - metashape-job
               topologyKey: "kubernetes.io/hostname"
+      # Use docker automate-metashape to do photogrammetry
       container:
         image: ghcr.io/open-forest-observatory/automate-metashape
         volumeMounts:

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -59,7 +59,7 @@ spec:
     
     # Use containerized python to parse through the list of datasets as specified from runtime parameter 'DATASET_LIST'
     # outputs a json of dataset names that is passed to the next steps
-    - name: determine-datasets
+    - name: determine-configs
       script:
         image: python:3.9
         volumeMounts:

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -210,7 +210,7 @@ spec:
         command: ["python3", "/app/python/metashape_workflow.py"]
         args:
           - "--config_file"
-          - "/data/argo-input/configs/{{inputs.parameters.dataset-name}}"
+          - "/data/argo-input/configs/{{inputs.parameters.dataset-name}}.yml"
           - "--project-path"
           - "/results/{{workflow.parameters.RUN_FOLDER}}/{{inputs.parameters.dataset-name}}/project"
           - "--output-path"

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -103,7 +103,7 @@ spec:
     - name: process-config-workflow
       inputs:
         parameters:
-          - name: dataset-name  
+          - name: config-file  
       steps:
         - - name: log-start
             template: log-config-start

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -10,12 +10,10 @@ spec:
   # These parameters can be referenced throughout the workflow templates using {{workflow.parameters.<name>}}.
   arguments:
     parameters:
-      - name: CONFIG_FILE
-        default: "config.yml"
+      - name: CONFIG_LIST
+        default: "config_list.txt"
       - name: RUN_FOLDER
         default: "default-run"
-      - name: DATASET_LIST
-        default: "datasets.txt"
       - name: AGISOFT_FLS
         default: ""
       - name: DB_HOST
@@ -41,21 +39,21 @@ spec:
     # the 'process-datasets' step has a looping directive (withParam) which goes through each dataset name and processes it. 
     - name: main
       steps:
-        - - name: determine-datasets
-            template: determine-datasets
-        - - name: log-datasets-to-db
-            template: log-datasets-to-db
+        - - name: determine-configs
+            template: determine-configs
+        - - name: log-configs-to-db
+            template: log-configs-to-db
             arguments:
               parameters:
-                - name: datasets
-                  value: "{{steps.determine-datasets.outputs.result}}"
-        - - name: process-datasets
-            template: process-dataset-workflow
+                - name: configs
+                  value: "{{steps.determine-configs.outputs.result}}"
+        - - name: process-configs
+            template: process-config-workflow
             arguments:
               parameters:
-                - name: dataset-name
+                - name: config-file
                   value: "{{item}}"
-            withParam: "{{steps.determine-datasets.outputs.result}}"
+            withParam: "{{steps.determine-configs.outputs.result}}"
 
     ## here we define what the main steps actually do 
     
@@ -67,7 +65,7 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /input
-          subPath: "argo-input/{{workflow.parameters.DATASET_LIST}}"
+          subPath: "argo-input/{{workflow.parameters.CONFIG_LIST}}"
         command: ["python3"]
         source: |
           import json
@@ -78,10 +76,10 @@ spec:
 
     # launches a docker container which contains our custom py script to log the dataset names into a postgis database
     # takes the json list of dataset names (from the 'determine datasets' step)
-    - name: log-datasets-to-db
+    - name: log-configs-to-db
       inputs:
         parameters:
-          - name: datasets
+          - name: configs
       container:
         image: ghcr.io/open-forest-observatory/ofo-argo-utils:latest
         command: ["python", "/app/db_logger.py"]
@@ -89,8 +87,8 @@ spec:
           - "log-initial"
           - "--workflow-id"
           - "{{workflow.name}}"
-          - "--datasets-json"
-          - "{{inputs.parameters.datasets}}"
+          - "--configs-json"
+          - "{{inputs.parameters.configs}}"
         env:
           - name: DB_HOST
             value: "{{workflow.parameters.DB_HOST}}"
@@ -102,25 +100,23 @@ spec:
             value: "{{workflow.parameters.DB_PASSWORD}}"
     
     # High-level order of steps in the workflow. Each step will be defined later.      
-    - name: process-dataset-workflow
+    - name: process-config-workflow
       inputs:
         parameters:
           - name: dataset-name  
       steps:
         - - name: log-start
-            template: log-dataset-start
+            template: log-config-start
             arguments:
               parameters:
-                - name: dataset-name
-                  value: "{{inputs.parameters.dataset-name}}"
+                - name: config-file
+                  value: "{{inputs.parameters.config-file}}"
         - - name: run-processing
             template: run-automate-metashape
             arguments:
               parameters:
-                - name: dataset-names
-                  value: "{{inputs.parameters.dataset-name}}" # Pass dataset name to Metashape container
                 - name: config-file
-                  value: "{{workflow.parameters.CONFIG_FILE}}" # Pass the global config file to control processing options
+                  value: "{{inputs.parameters.config-file}}" 
             continueOn:
               failed: true  # EVEN IF this step fails, keep the workflow running (needed to log failure in DB later)
         - - name: determine-success
@@ -130,21 +126,21 @@ spec:
                 - name: step-status
                   value: "{{steps.run-processing.status}}"
         - - name: log-completion
-            template: log-dataset-completion
+            template: log-config-completion
             arguments:
               parameters:
-                - name: dataset-name
-                  value: "{{inputs.parameters.dataset-name}}"
+                - name: config-file
+                  value: "{{inputs.parameters.config-file}}"
                 - name: success
                   value: "{{steps.determine-success.outputs.result}}"      
 
     ## Here we define what each step does
     
     # use our custom containerized db_logger.py to log 'processing' in the postgis DB
-    - name: log-dataset-start
+    - name: log-config-start
       inputs:
         parameters:
-          - name: dataset-name
+          - name: config-file
       container:
         image: ghcr.io/open-forest-observatory/ofo-argo-utils:latest
         command: ["python", "/app/db_logger.py"]
@@ -152,8 +148,8 @@ spec:
           - "log-start"
           - "--workflow-id"
           - "{{workflow.name}}"
-          - "--dataset"
-          - "{{inputs.parameters.dataset-name}}"
+          - "--config"
+          - "{{inputs.parameters.config-file}}"
         env:
           - name: DB_HOST
             value: "{{workflow.parameters.DB_HOST}}"
@@ -165,10 +161,10 @@ spec:
             value: "{{workflow.parameters.DB_PASSWORD}}"
     
     # use our custom containerized db_logger.py to log 'completed' or 'failed' in the postgis DB
-    - name: log-dataset-completion
+    - name: log-config-completion
       inputs:
         parameters:
-          - name: dataset-name
+          - name: config-file
           - name: success
       container:
         image: ghcr.io/open-forest-observatory/ofo-argo-utils:latest
@@ -177,8 +173,8 @@ spec:
           - "log-completion"
           - "--workflow-id"
           - "{{workflow.name}}"
-          - "--dataset"
-          - "{{inputs.parameters.dataset-name}}"
+          - "--config"
+          - "{{inputs.parameters.config-file}}"
           - "--success"
           - "{{inputs.parameters.success}}"
         env:
@@ -208,7 +204,6 @@ spec:
     - name: run-automate-metashape
       inputs:
         parameters:
-          - name: dataset-names
           - name: config-file
       # the following 'metadata' and 'affinity' language is about ensuring one metashape project on one VM
       metadata:
@@ -237,15 +232,15 @@ spec:
         command: ["python3", "/app/python/metashape_workflow.py"]
         args: 
           - "--config_file"
-          - "/data/argo-input/{{inputs.parameters.config-file}}"
-          - "--photo-path"
-          - "/data/argo-input/{{inputs.parameters.dataset-names}}"
+          - "/data/argo-input/configs/{{inputs.parameters.config-file}}"
+          #- "--photo-path"
+          #- "/data/argo-input/{{inputs.parameters.dataset-names}}"
           - "--project-path"
-          - "/results/{{workflow.parameters.RUN_FOLDER}}/{{inputs.parameters.dataset-names}}/project"
+          - "/results/{{workflow.parameters.RUN_FOLDER}}/{{inputs.parameters.config-file}}/project"
           - "--output-path"
-          - "/results/{{workflow.parameters.RUN_FOLDER}}/{{inputs.parameters.dataset-names}}/output"
+          - "/results/{{workflow.parameters.RUN_FOLDER}}/{{inputs.parameters.config-file}}/output"
           - "--run-name"
-          - "{{inputs.parameters.dataset-names}}"
+          - "{{inputs.parameters.config-file}}"
         env:
           - name: AGISOFT_FLS
             value: "{{workflow.parameters.AGISOFT_FLS}}"


### PR DESCRIPTION
These changes give more customization to the argo workflow. Each drone imagery dataset now needs it's own metashape config.yml. Whereas before, you could only use one config.yml for all your datasets. Thorough documentation has been added to explain how to organize argo inputs on the '/ofo-share' directory. This includes a dedicated directory for image datasets, a dedicated directory for config.ymls, and new 'config_list.txt' file. Additional documentation explains the updated 'run' command or argo.

This 'config list' workflow has been stress tested on ~200 datasets. 