### PR TITLE
Jgillan/s3 upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,16 @@ This variable will only last during the terminal session and will have to be re-
 
 <br/>
 
+### 2. Declare credentials for upload to S3 bucket
+
+OFO has a S3 bucket with Jetstream2. The final step of the workflow will upload the <RUN_FOLDER> to the S3 bucket. 
+
+Please create a kubernetes secret to store the S3 Access ID and Secret Key
+
+```
+kubectl create secret generic s3-credentials \ --from-literal=access_key=<YOUR_ACCESS_KEY_ID> \ --from-literal=secret_key=<YOUR_SECRET_ACCESS_KEY> \ -n argo 
+```
+
 ### 2. Run!!
 
 ```
@@ -394,7 +404,11 @@ argo submit -n argo workflow.yaml --watch \
 -p DB_PASSWORD=<password> \
 -p DB_HOST=<vm_ip_address> \
 -p DB_NAME=<db_name> \
--p DB_USER=<user_name>
+-p DB_USER=<user_name> \
+-p S3_BUCKET=ofo-public \
+-p S3_PROVIDER=Other \
+-p S3_ENDPOINT=https://js2.jetstream-cloud.org:8001
+
  
 ```
 
@@ -405,6 +419,8 @@ AGISOFT_FLS is the ip address of the metashape license server
 RUN_FOLDER is what you want to name the parent directory of your output
 
 The rest of the 'DB' parameters are for logging argo status in a postGIS database. These are not public credentials. Authorized users can find them [here](https://docs.google.com/document/d/155AP0P3jkVa-yT53a-QLp7vBAfjRa78gdST1Dfb4fls/edit?tab=t.0).
+
+The 'S3' parameters are related to uploading outputs to Jetstream2 S3 bucket 
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ Please create a kubernetes secret to store the S3 Access ID and Secret Key
 kubectl create secret generic s3-credentials \ --from-literal=access_key=<YOUR_ACCESS_KEY_ID> \ --from-literal=secret_key=<YOUR_SECRET_ACCESS_KEY> \ -n argo 
 ```
 
-### 2. Run!!
+### 3. Run!!
 
 ```
 argo submit -n argo workflow.yaml --watch \
@@ -424,7 +424,7 @@ The 'S3' parameters are related to uploading outputs to Jetstream2 S3 bucket
 
 <br/>
 
-### 3. Monitor Argo Workflow
+### 4. Monitor Argo Workflow
 The Argo UI is great for troubleshooting and checking additional logs. You can access it either through the Cacao WebDesktop or ssh from your local terminal.
 
 #### WebDesktop Method
@@ -505,7 +505,7 @@ A successfull argo run
 <br/>
 
 
-### 4. Metashape Outputs
+### 5. Metashape Outputs
 The metashape outputs will be written to `/ofo-share/argo-outputs/<RUN_FOLDER>`. Each dataset will have its own subdirectory in the <RUN_FOLDER>. Output imagery products (DEMs, orthomosaics, point clouds, report) will be written to `/ofo-share/argo-outputs/<RUN_FOLDER>/<dataset_name>/output`. Metashape projects .psx will be written to `/ofo-share/argo-outputs/<RUN_FOLDER>/<dataset_name>/project`.
 
 ```bash
@@ -548,7 +548,7 @@ The metashape outputs will be written to `/ofo-share/argo-outputs/<RUN_FOLDER>`.
 <br/>
 <br/>
 
-### 5. Argo Workflow Logging in postGIS database 
+### 6. Argo Workflow Logging in postGIS database 
 
 Argo run status is logged into a postGIS DB. This is done through an additional docker container (hosted on github container registry `ghcr.io/open-forest-observatory/ofo-argo-utils:latest`) that is included in the argo workflow. The files to make the docker image are in the folder `ofo-argo-utils`. 
 

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -288,7 +288,25 @@ spec:
               --s3-upload-cutoff 200Mi --s3-chunk-size 100Mi --s3-upload-concurrency 4 \
               --stats 15s --stats-log-level NOTICE
 
-            echo "[rclone] Upload complete."
+            echo "[rclone] Upload complete. Starting verification..."
+
+            # Verify the upload by checking file name and size
+            rclone check "$SRC" "$DST" \
+              --s3-provider "{{workflow.parameters.S3_PROVIDER}}" \
+              --s3-endpoint "{{workflow.parameters.S3_ENDPOINT}}" \
+              --s3-access-key-id "$RCLONE_S3_ACCESS_KEY_ID" \
+              --s3-secret-access-key "$RCLONE_S3_SECRET_ACCESS_KEY" \
+              --checkfile /tmp/rclone-check.log
+
+            if [ $? -eq 0 ]; then
+              echo "[rclone] Verification successful - all files match!"
+              echo "UPLOAD_VERIFIED=true" > /results/upload_status_{{inputs.parameters.dataset-name}}.txt
+            else
+              echo "[rclone] Verification failed - some files don't match!"
+              cat /tmp/rclone-check.log
+              echo "UPLOAD_VERIFIED=false" > /results/upload_status_{{inputs.parameters.dataset-name}}.txt
+              exit 1
+            fi
 
         # Light footprint so it can co-locate with Metashape if the node has room.
         resources:

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -24,6 +24,13 @@ spec:
         default: ""
       - name: DB_PASSWORD
         default: ""
+      # S3 / rclone upload parameters
+      - name: S3_BUCKET
+        default: ""
+      - name: S3_ENDPOINT
+        default: ""
+      - name: S3_PROVIDER
+        default: ""      # e.g., AWS, Minio, Ceph
 
   # Defining where to read raw drone imagery data and write out imagery products to `/ofo-share`
   volumes:
@@ -110,14 +117,15 @@ spec:
       inputs:
         parameters:
           - name: dataset-name
-      steps:
-        - - name: log-start
+      dag:
+        tasks:
+          - name: log-start
             template: log-dataset-start
             arguments:
               parameters:
                 - name: dataset-name
                   value: "{{inputs.parameters.dataset-name}}"
-        - - name: run-processing
+          - name: run-processing
             template: run-automate-metashape
             arguments:
               parameters:
@@ -125,13 +133,21 @@ spec:
                   value: "{{inputs.parameters.dataset-name}}"
             continueOn:
               failed: true
-        - - name: determine-success
+          # As soon as processing finishes, kick off upload in parallel on any available node
+          - name: rclone-upload
+            dependencies: [run-processing]
+            template: rclone-upload-to-s3
+            arguments:
+              parameters:
+                - name: dataset-name
+                  value: "{{inputs.parameters.dataset-name}}"
+          - name: determine-success
             template: evaluate-success
             arguments:
               parameters:
                 - name: step-status
                   value: "{{steps.run-processing.status}}"
-        - - name: log-completion
+          - name: log-completion
             template: log-dataset-completion
             arguments:
               parameters:
@@ -246,5 +262,53 @@ spec:
         env:
           - name: AGISOFT_FLS
             value: "{{workflow.parameters.AGISOFT_FLS}}"
+            
+  # --------- RCLONE UPLOAD (Docker image) ---------
+    - name: rclone-upload-to-s3
+      inputs:
+        parameters:
+          - name: dataset-name
+      container:
+        image: rclone/rclone:latest
+        volumeMounts:
+          - name: results
+            mountPath: /results
+        command: ["/bin/sh", "-lc"]
+        args:
+          - |
+            set -euo pipefail
+            SRC="/results/{{workflow.parameters.RUN_FOLDER}}/{{inputs.parameters.dataset-name}}"
+            DST="s3:{{workflow.parameters.S3_BUCKET}}/{{workflow.parameters.RUN_FOLDER}}/{{inputs.parameters.dataset-name}}"
 
-         
+            echo "[rclone] Uploading $SRC -> $DST"
+            rclone copy "$SRC" "$DST" \
+              --s3-provider "{{workflow.parameters.S3_PROVIDER}}" \
+              --s3-endpoint "{{workflow.parameters.S3_ENDPOINT}}" \
+              --s3-access-key-id "$RCLONE_S3_ACCESS_KEY_ID" \
+              --s3-secret-access-key "$RCLONE_S3_SECRET_ACCESS_KEY" \
+              --transfers 16 --checkers 16 --retries 5 --retries-sleep=15s \
+              --s3-upload-cutoff 100Mi --s3-chunk-size 100Mi --s3-upload-concurrency 8 \
+              --stats 15s --stats-log-level NOTICE
+
+            echo "[rclone] Upload complete."
+
+        # Light footprint so it can co-locate with Metashape if the node has room.
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "256Mi"
+          limits:
+            cpu: "1"
+            memory: "1Gi"
+        env:
+          - name: RCLONE_S3_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: s3-credentials
+                key: access_key
+          - name: RCLONE_S3_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: s3-credentials
+                key: secret_key
+      

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -125,6 +125,7 @@ spec:
               parameters:
                 - name: dataset-name
                   value: "{{inputs.parameters.dataset-name}}"
+                  
           - name: run-processing
             template: run-automate-metashape
             arguments:
@@ -133,6 +134,7 @@ spec:
                   value: "{{inputs.parameters.dataset-name}}"
             continueOn:
               failed: true
+              
           # As soon as processing finishes, kick off upload in parallel on any available node
           - name: rclone-upload
             dependencies: [run-processing]
@@ -141,20 +143,28 @@ spec:
               parameters:
                 - name: dataset-name
                   value: "{{inputs.parameters.dataset-name}}"
-          - name: determine-success
-            template: evaluate-success
-            arguments:
-              parameters:
-                - name: step-status
-                  value: "{{tasks.run-processing.outputs.exitCode}}"  #CHANGE HERE!!
-          - name: log-completion
+                  
+          - name: log-completion-success
+            dependencies: [run-processing]
             template: log-dataset-completion
             arguments:
               parameters:
                 - name: dataset-name
                   value: "{{inputs.parameters.dataset-name}}"
                 - name: success
-                  value: "{{tasks.determine-success.outputs.result}}"
+                  value: "true"
+            when: "{{tasks.run-processing.status}} == Succeeded"
+
+          - name: log-completion-failure
+            dependencies: [run-processing]
+            template: log-dataset-completion
+            arguments:
+              parameters:
+                - name: dataset-name
+                  value: "{{inputs.parameters.dataset-name}}"
+                - name: success
+                  value: "false"
+            when: "{{tasks.run-processing.status}} != Succeeded"
                   
     ## Here we define what each step does in 'process-dataset-workflow' step
     
@@ -208,19 +218,7 @@ spec:
             value: "{{workflow.parameters.DB_USER}}"
           - name: DB_PASSWORD
             value: "{{workflow.parameters.DB_PASSWORD}}"
-            
-    # Script to determine success of failure of step
-    - name: evaluate-success
-      inputs:
-        parameters:
-          - name: step-status
-      script:
-        image: python:3.9
-        command: ["python3"]
-        source: |
-          import sys
-          status = "{{inputs.parameters.step-status}}"
-          sys.stdout.write("true" if status == "Succeeded" else "false")
+        
           
     # Defining how to process each dataset name
     - name: run-automate-metashape

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -146,7 +146,7 @@ spec:
             arguments:
               parameters:
                 - name: step-status
-                  value: "{{tasks.run-processing.status}}"
+                  value: "{{tasks.run-processing.outputs.exitCode}}"  #CHANGE HERE!!
           - name: log-completion
             template: log-dataset-completion
             arguments:

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -297,15 +297,22 @@ spec:
               --s3-access-key-id "$RCLONE_S3_ACCESS_KEY_ID" \
               --s3-secret-access-key "$RCLONE_S3_SECRET_ACCESS_KEY" \
               --one-way \
-              --differ /results/s3_failures_{{inputs.parameters.dataset-name}}.log
+              --differ /tmp/s3_failures_temp.log
 
             if [ $? -eq 0 ]; then
               echo "[rclone] Verification successful - all files match!"
+              # Clean up temp file since verification passed
+              rm -f /tmp/s3_failures_temp.log
             else
               echo "[rclone] Verification failed - some files don't match!"
-              if [ -f /results/s3_failures_{{inputs.parameters.dataset-name}}.log ]; then
+              # Only create the persistent log file if there are actual failures
+              if [ -s /tmp/s3_failures_temp.log ]; then
+                mv /tmp/s3_failures_temp.log /results/s3_failures_{{inputs.parameters.dataset-name}}.log
                 echo "Files that differ:"
-                cat /results/s3_failures_{{inputs.parameters.dataset-name}}.log   #writes to file the files that did not complete
+                cat /results/s3_failures_{{inputs.parameters.dataset-name}}.log
+              else
+                echo "No specific file differences found (general rclone error)"
+                rm -f /tmp/s3_failures_temp.log
               fi
               exit 1
             fi

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -146,7 +146,7 @@ spec:
             arguments:
               parameters:
                 - name: step-status
-                  value: "{{steps.run-processing.status}}"
+                  value: "{{tasks.run-processing.status}}"
           - name: log-completion
             template: log-dataset-completion
             arguments:
@@ -154,7 +154,7 @@ spec:
                 - name: dataset-name
                   value: "{{inputs.parameters.dataset-name}}"
                 - name: success
-                  value: "{{steps.determine-success.outputs.result}}"
+                  value: "{{tasks.determine-success.outputs.result}}"
                   
     ## Here we define what each step does in 'process-dataset-workflow' step
     

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -284,8 +284,8 @@ spec:
               --s3-endpoint "{{workflow.parameters.S3_ENDPOINT}}" \
               --s3-access-key-id "$RCLONE_S3_ACCESS_KEY_ID" \
               --s3-secret-access-key "$RCLONE_S3_SECRET_ACCESS_KEY" \
-              --transfers 16 --checkers 16 --retries 5 --retries-sleep=15s \
-              --s3-upload-cutoff 100Mi --s3-chunk-size 100Mi --s3-upload-concurrency 8 \
+              --transfers 8 --checkers 8 --retries 5 --retries-sleep=15s \
+              --s3-upload-cutoff 200Mi --s3-chunk-size 100Mi --s3-upload-concurrency 4 \
               --stats 15s --stats-log-level NOTICE
 
             echo "[rclone] Upload complete."
@@ -297,7 +297,7 @@ spec:
             memory: "256Mi"
           limits:
             cpu: "1"
-            memory: "1Gi"
+            memory: "2Gi"
         env:
           - name: RCLONE_S3_ACCESS_KEY_ID
             valueFrom:

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -288,34 +288,7 @@ spec:
               --s3-upload-cutoff 200Mi --s3-chunk-size 100Mi --s3-upload-concurrency 4 \
               --stats 15s --stats-log-level NOTICE
 
-            echo "[rclone] Upload complete. Starting verification..."
-
-            # Verify the upload by checking file name and size
-            rclone check "$SRC" "$DST" \
-              --s3-provider "{{workflow.parameters.S3_PROVIDER}}" \
-              --s3-endpoint "{{workflow.parameters.S3_ENDPOINT}}" \
-              --s3-access-key-id "$RCLONE_S3_ACCESS_KEY_ID" \
-              --s3-secret-access-key "$RCLONE_S3_SECRET_ACCESS_KEY" \
-              --one-way \
-              --differ /tmp/s3_failures_temp.log
-
-            if [ $? -eq 0 ]; then
-              echo "[rclone] Verification successful - all files match!"
-              # Clean up temp file since verification passed
-              rm -f /tmp/s3_failures_temp.log
-            else
-              echo "[rclone] Verification failed - some files don't match!"
-              # Only create the persistent log file if there are actual failures
-              if [ -s /tmp/s3_failures_temp.log ]; then
-                mv /tmp/s3_failures_temp.log /results/s3_failures_{{inputs.parameters.dataset-name}}.log
-                echo "Files that differ:"
-                cat /results/s3_failures_{{inputs.parameters.dataset-name}}.log
-              else
-                echo "No specific file differences found (general rclone error)"
-                rm -f /tmp/s3_failures_temp.log
-              fi
-              exit 1
-            fi
+            echo "[rclone] Upload complete. "
 
         # Light footprint so it can co-locate with Metashape if the node has room.
         resources:

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -297,18 +297,16 @@ spec:
               --s3-access-key-id "$RCLONE_S3_ACCESS_KEY_ID" \
               --s3-secret-access-key "$RCLONE_S3_SECRET_ACCESS_KEY" \
               --one-way \
-              --differ /tmp/rclone-check.log 
+              --differ /results/s3_failures_{{inputs.parameters.dataset-name}}.log
 
             if [ $? -eq 0 ]; then
               echo "[rclone] Verification successful - all files match!"
-              echo "UPLOAD_VERIFIED=true" > /results/upload_status_{{inputs.parameters.dataset-name}}.txt
             else
               echo "[rclone] Verification failed - some files don't match!"
-              if [ -f /tmp/rclone-check.log ]; then
+              if [ -f /results/s3_failures_{{inputs.parameters.dataset-name}}.log ]; then
                 echo "Files that differ:"
-                cat /tmp/rclone-check.log
+                cat /results/s3_failures_{{inputs.parameters.dataset-name}}.log   #writes to file the files that did not complete
               fi
-              echo "UPLOAD_VERIFIED=false" > /results/upload_status_{{inputs.parameters.dataset-name}}.txt
               exit 1
             fi
 

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -276,7 +276,7 @@ spec:
           - |
             set -euo pipefail
             SRC="/results/{{workflow.parameters.RUN_FOLDER}}/{{inputs.parameters.dataset-name}}"
-            DST="s3:{{workflow.parameters.S3_BUCKET}}/{{workflow.parameters.RUN_FOLDER}}/{{inputs.parameters.dataset-name}}"
+            DST=":s3:{{workflow.parameters.S3_BUCKET}}/{{workflow.parameters.RUN_FOLDER}}/{{inputs.parameters.dataset-name}}"
 
             echo "[rclone] Uploading $SRC -> $DST"
             rclone copy "$SRC" "$DST" \

--- a/workflow.yaml
+++ b/workflow.yaml
@@ -296,14 +296,18 @@ spec:
               --s3-endpoint "{{workflow.parameters.S3_ENDPOINT}}" \
               --s3-access-key-id "$RCLONE_S3_ACCESS_KEY_ID" \
               --s3-secret-access-key "$RCLONE_S3_SECRET_ACCESS_KEY" \
-              --checkfile /tmp/rclone-check.log
+              --one-way \
+              --differ /tmp/rclone-check.log 
 
             if [ $? -eq 0 ]; then
               echo "[rclone] Verification successful - all files match!"
               echo "UPLOAD_VERIFIED=true" > /results/upload_status_{{inputs.parameters.dataset-name}}.txt
             else
               echo "[rclone] Verification failed - some files don't match!"
-              cat /tmp/rclone-check.log
+              if [ -f /tmp/rclone-check.log ]; then
+                echo "Files that differ:"
+                cat /tmp/rclone-check.log
+              fi
               echo "UPLOAD_VERIFIED=false" > /results/upload_status_{{inputs.parameters.dataset-name}}.txt
               exit 1
             fi


### PR DESCRIPTION
Workflow now has an extra task that uploads finished metashape outputs to the Js2 S3 cloud bucket. 

- When a pod finishes the metashape run and writes outputs to the ‘ofo-share’ drive, a new workflow task starts which transfers data into S3. This transfer runs on any worker and simultaneously as a metashape run on the same worker. 

- It’s a bit tricky to specify all the computing resources to allocate to the transfer (ram, chunk size, vcpus). Testing best practices. 

- Currently, S3 credentials (endpoint, bucket name, provider) are specified in the argo run command. More sensitive credentials (access ID, access key) are declared as a Kubernetes secret before the run. 

- The <RUN_FOLDER> and all its children are uploaded to ‘js2s3:/ofo-public’ root directory meaning it will be ‘js2s3:/ofo-public/<RUN_FOLDER>

- Should we automatically delete the files that were written to the ‘ofo-share’ directory?

Run this command in the terminal before you start the argo workflow:
`kubectl create secret generic s3-credentials \
  --from-literal=access_key=<YOUR_ACCESS_KEY_ID> \
  --from-literal=secret_key=<YOUR_SECRET_ACCESS_KEY> \
  -n argo
`
New argo workflow run command:
`argo submit -n argo workflow.yaml --watch \
-p CONFIG_LIST=config_list.txt \
-p AGISOFT_FLS=$AGISOFT_FLS \
-p RUN_FOLDER=<run_folder_name> \
-p DB_PASSWORD=<password> \
-p DB_HOST=<vm_ip_address> \
-p DB_NAME=<db_name> \
-p DB_USER=<user_name>
-p S3_BUCKET=ofo-public \
-p S3_PROVIDER=Other \
-p S3_ENDPOINT=https://js2.jetstream-cloud.org:8001`

