### PR TITLE
Migrate to new input/output PVC and remove logging

### DIFF
--- a/workflow.yaml
+++ b/workflow.yaml
@@ -125,18 +125,21 @@ spec:
         volumeMounts:
           - name: data
             mountPath: /data
-          - name: results
-            mountPath: /results
         command: ["python3", "/app/python/metashape_workflow.py"]
         args:
           - "--config_file"
           - "/data/argo-input/configs/{{inputs.parameters.dataset-name}}.yml"
           - "--project-path"
-          - "/results/{{workflow.parameters.RUN_FOLDER}}/{{inputs.parameters.dataset-name}}/project"
+          - "/data/argo-output/{{workflow.parameters.RUN_FOLDER}}/{{inputs.parameters.dataset-name}}/project"
           - "--output-path"
-          - "/results/{{workflow.parameters.RUN_FOLDER}}/{{inputs.parameters.dataset-name}}/output"
+          - "/data/argo-output/{{workflow.parameters.RUN_FOLDER}}/{{inputs.parameters.dataset-name}}/output"
           - "--run-name"
           - "{{inputs.parameters.dataset-name}}"
+        resources:
+          requests:
+            nvidia.com/gpu: 1
+          limits:
+            nvidia.com/gpu: 1
         env:
           - name: AGISOFT_FLS
             value: "{{workflow.parameters.AGISOFT_FLS}}"


### PR DESCRIPTION
This updates to only use a single PVC, which is now backed by the CEPH-based `/ofo-share-2`. Also, it removes logging, since that's not currently being used and adds `requests` and `limits` to ensure the jobs are scheduled on a GPU-enabled node.