### PR TITLE
Move transformed photogrammetry config to under project photogrammetry temp folder

### DIFF
--- a/docker-workflow-utils/transform_config.py
+++ b/docker-workflow-utils/transform_config.py
@@ -11,7 +11,7 @@ Usage:
 
 Environment Variables:
     CONFIG_FILE: Path to the original config file
-    OUTPUT_CONFIG_FILE: Path to write the transformed config (e.g., '{TEMP_WORKING_DIR}/{workflow_name}/configs/{iteration_id}-transformed.yml')
+    OUTPUT_CONFIG_FILE: Path to write the transformed config (e.g., '{TEMP_WORKING_DIR}/{workflow_name}/{iteration_id}/photogrammetry/config-transformed.yml')
     DOWNLOADED_IMAGERY_PATH: Actual path to downloaded imagery directory (e.g., '{TEMP_WORKING_DIR}/{workflow_name}/{iteration_id}/photogrammetry/downloaded-raw-imagery')
 
 Output:

--- a/photogrammetry-workflow-stepbased.yaml
+++ b/photogrammetry-workflow-stepbased.yaml
@@ -758,7 +758,7 @@ spec:
           - name: CONFIG_FILE
             value: "{{inputs.parameters.config-file}}"
           - name: OUTPUT_CONFIG_FILE
-            value: "{{workflow.parameters.TEMP_WORKING_DIR}}/{{workflow.name}}/configs/{{inputs.parameters.iteration-id}}-transformed.yml"
+            value: "{{workflow.parameters.TEMP_WORKING_DIR}}/{{workflow.name}}/{{inputs.parameters.iteration-id}}/photogrammetry/config-transformed.yml"
           - name: DOWNLOADED_IMAGERY_PATH
             value: "{{workflow.parameters.TEMP_WORKING_DIR}}/{{workflow.name}}/{{inputs.parameters.iteration-id}}/photogrammetry/downloaded-raw-imagery"
         resources:
@@ -768,7 +768,7 @@ spec:
       outputs:
         parameters:
           - name: transformed-config-path
-            value: "{{workflow.parameters.TEMP_WORKING_DIR}}/{{workflow.name}}/configs/{{inputs.parameters.iteration-id}}-transformed.yml"
+            value: "{{workflow.parameters.TEMP_WORKING_DIR}}/{{workflow.name}}/{{inputs.parameters.iteration-id}}/photogrammetry/config-transformed.yml"
 
     # --------- RCLONE UPLOAD (Docker image) ---------
     - name: rclone-upload-template


### PR DESCRIPTION
Copilot summary:

This pull request updates the location and naming convention for transformed configuration files in the photogrammetry workflow. The changes ensure that transformed config files are stored in a more organized and consistent directory structure under each workflow iteration.

**Config file path updates:**

* Updated the `OUTPUT_CONFIG_FILE` environment variable description in `transform_config.py` to reflect the new path: transformed config files are now written to `{TEMP_WORKING_DIR}/{workflow_name}/{iteration_id}/photogrammetry/config-transformed.yml` instead of the previous `configs` directory.
* Changed the `OUTPUT_CONFIG_FILE` parameter value in `photogrammetry-workflow-stepbased.yaml` to use the new directory structure and filename.
* Updated the `transformed-config-path` output parameter in `photogrammetry-workflow-stepbased.yaml` to match the new path for transformed config files.