### PR TITLE
Enhance determine_datasets.py and workflow YAML to support outputting full configs to a file

### DIFF
--- a/photogrammetry-workflow-stepbased.yaml
+++ b/photogrammetry-workflow-stepbased.yaml
@@ -69,103 +69,22 @@ spec:
             template: compute-photogrammetry-config-subfolder
           - name: determine-projects
             template: determine-projects
+        # withParam now receives only minimal references (index + project_name) to avoid
+        # Argo's parameter size limit. Each project loads its full config from the shared file.
         - - name: process-projects
             template: process-project-workflow
             arguments:
               parameters:
+                # Minimal reference - full config loaded from file at runtime
+                - name: project-index
+                  value: "{{item.index}}"
                 - name: project-name
                   value: "{{item.project_name}}"
-                - name: config-file
-                  value: "{{item.config}}"
+                # Path to shared configs file
+                - name: configs-file
+                  value: "{{steps.determine-projects.outputs.parameters.configs-file}}"
                 - name: photogrammetry-config-subfolder
                   value: "{{steps.compute-photogrammetry-config-subfolder.outputs.result}}"
-                # Step enabled flags
-                - name: match_photos_enabled
-                  value: "{{item.match_photos_enabled}}"
-                - name: match_photos_use_gpu
-                  value: "{{item.match_photos_use_gpu}}"
-                - name: match_photos_gpu_resource
-                  value: "{{item.match_photos_gpu_resource}}"
-                - name: match_photos_gpu_count
-                  value: "{{item.match_photos_gpu_count}}"
-                - name: align_cameras_enabled
-                  value: "{{item.align_cameras_enabled}}"
-                - name: build_depth_maps_enabled
-                  value: "{{item.build_depth_maps_enabled}}"
-                - name: build_depth_maps_gpu_resource
-                  value: "{{item.build_depth_maps_gpu_resource}}"
-                - name: build_depth_maps_gpu_count
-                  value: "{{item.build_depth_maps_gpu_count}}"
-                - name: build_point_cloud_enabled
-                  value: "{{item.build_point_cloud_enabled}}"
-                - name: build_mesh_enabled
-                  value: "{{item.build_mesh_enabled}}"
-                - name: build_mesh_use_gpu
-                  value: "{{item.build_mesh_use_gpu}}"
-                - name: build_mesh_gpu_resource
-                  value: "{{item.build_mesh_gpu_resource}}"
-                - name: build_mesh_gpu_count
-                  value: "{{item.build_mesh_gpu_count}}"
-                - name: build_dem_orthomosaic_enabled
-                  value: "{{item.build_dem_orthomosaic_enabled}}"
-                - name: match_photos_secondary_enabled
-                  value: "{{item.match_photos_secondary_enabled}}"
-                - name: match_photos_secondary_use_gpu
-                  value: "{{item.match_photos_secondary_use_gpu}}"
-                - name: match_photos_secondary_gpu_resource
-                  value: "{{item.match_photos_secondary_gpu_resource}}"
-                - name: match_photos_secondary_gpu_count
-                  value: "{{item.match_photos_secondary_gpu_count}}"
-                - name: align_cameras_secondary_enabled
-                  value: "{{item.align_cameras_secondary_enabled}}"
-                # CPU/memory request parameters
-                - name: setup_cpu_request
-                  value: "{{item.setup_cpu_request}}"
-                - name: setup_memory_request
-                  value: "{{item.setup_memory_request}}"
-                - name: match_photos_cpu_request
-                  value: "{{item.match_photos_cpu_request}}"
-                - name: match_photos_memory_request
-                  value: "{{item.match_photos_memory_request}}"
-                - name: align_cameras_cpu_request
-                  value: "{{item.align_cameras_cpu_request}}"
-                - name: align_cameras_memory_request
-                  value: "{{item.align_cameras_memory_request}}"
-                - name: build_depth_maps_cpu_request
-                  value: "{{item.build_depth_maps_cpu_request}}"
-                - name: build_depth_maps_memory_request
-                  value: "{{item.build_depth_maps_memory_request}}"
-                - name: build_point_cloud_cpu_request
-                  value: "{{item.build_point_cloud_cpu_request}}"
-                - name: build_point_cloud_memory_request
-                  value: "{{item.build_point_cloud_memory_request}}"
-                - name: build_mesh_cpu_request
-                  value: "{{item.build_mesh_cpu_request}}"
-                - name: build_mesh_memory_request
-                  value: "{{item.build_mesh_memory_request}}"
-                - name: build_dem_orthomosaic_cpu_request
-                  value: "{{item.build_dem_orthomosaic_cpu_request}}"
-                - name: build_dem_orthomosaic_memory_request
-                  value: "{{item.build_dem_orthomosaic_memory_request}}"
-                - name: match_photos_secondary_cpu_request
-                  value: "{{item.match_photos_secondary_cpu_request}}"
-                - name: match_photos_secondary_memory_request
-                  value: "{{item.match_photos_secondary_memory_request}}"
-                - name: align_cameras_secondary_cpu_request
-                  value: "{{item.align_cameras_secondary_cpu_request}}"
-                - name: align_cameras_secondary_memory_request
-                  value: "{{item.align_cameras_secondary_memory_request}}"
-                - name: finalize_cpu_request
-                  value: "{{item.finalize_cpu_request}}"
-                - name: finalize_memory_request
-                  value: "{{item.finalize_memory_request}}"
-                # S3 imagery download parameters
-                - name: iteration-id
-                  value: "{{item.iteration_id}}"
-                - name: imagery-zip-downloads
-                  value: "{{item.imagery_zip_downloads}}"
-                - name: imagery-download-enabled
-                  value: "{{item.imagery_download_enabled}}"
             withParam: "{{steps.determine-projects.outputs.result}}"
 
     ## Here we define what the main steps actually do
@@ -191,6 +110,10 @@ spec:
     # This reads each mission's config file, extracts the project name, and determines which
     # processing steps are enabled. It also determines GPU vs CPU node scheduling for GPU-capable steps.
     # Uses containerized preprocessing script from argo-workflow-utils.
+    #
+    # To avoid Argo's parameter size limit (default 256KB), this step writes full configs to a
+    # shared file and outputs only minimal references (index + project_name) to stdout.
+    # Each project iteration loads its full config from the shared file at runtime.
     - name: determine-projects
       # Ensure CPU pods only schedule on CPU nodes (labeled by NFD based on nodegroup name)
       nodeSelector:
@@ -201,342 +124,339 @@ spec:
           - name: data
             mountPath: /data
         command: ["python3"]
-        args: ["/app/determine_datasets.py", "{{workflow.parameters.CONFIG_LIST}}"]
+        args:
+          - "/app/determine_datasets.py"
+          - "{{workflow.parameters.CONFIG_LIST}}"
+          # Write full configs to shared file (artifact mode) to avoid withParam size limits
+          - "{{workflow.parameters.TEMP_WORKING_DIR}}/{{workflow.name}}/project-configs.json"
+      outputs:
+        parameters:
+          - name: configs-file
+            value: "{{workflow.parameters.TEMP_WORKING_DIR}}/{{workflow.name}}/project-configs.json"
+
+    # Load a single project's configuration from the shared configs file
+    # This avoids passing large JSON through Argo parameters (which has size limits)
+    - name: load-project-config
+      inputs:
+        parameters:
+          - name: configs-file
+          - name: project-index
+      nodeSelector:
+        feature.node.kubernetes.io/workload-type: cpu
+      script:
+        image: python:3.9-slim
+        volumeMounts:
+          - name: data
+            mountPath: /data
+        command: ["python3"]
+        source: |
+          import json
+          with open("{{inputs.parameters.configs-file}}", "r") as f:
+              configs = json.load(f)
+          project_config = configs[{{inputs.parameters.project-index}}]
+          print(json.dumps(project_config))
 
     # Multi-step photogrammetry workflow with conditional GPU/CPU execution
+    # Config is loaded from shared file at runtime to avoid Argo parameter size limits
     - name: process-project-workflow
       inputs:
         parameters:
+          - name: project-index
           - name: project-name
-          - name: config-file
+          - name: configs-file
           - name: photogrammetry-config-subfolder
-          # Step enabled flags
-          - name: match_photos_enabled
-          - name: match_photos_use_gpu
-          - name: match_photos_gpu_resource
-          - name: match_photos_gpu_count
-          - name: align_cameras_enabled
-          - name: build_depth_maps_enabled
-          - name: build_depth_maps_gpu_resource
-          - name: build_depth_maps_gpu_count
-          - name: build_point_cloud_enabled
-          - name: build_mesh_enabled
-          - name: build_mesh_use_gpu
-          - name: build_mesh_gpu_resource
-          - name: build_mesh_gpu_count
-          - name: build_dem_orthomosaic_enabled
-          - name: match_photos_secondary_enabled
-          - name: match_photos_secondary_use_gpu
-          - name: match_photos_secondary_gpu_resource
-          - name: match_photos_secondary_gpu_count
-          - name: align_cameras_secondary_enabled
-          # CPU/memory request parameters for ALL steps
-          - name: setup_cpu_request
-          - name: setup_memory_request
-          - name: match_photos_cpu_request
-          - name: match_photos_memory_request
-          - name: align_cameras_cpu_request
-          - name: align_cameras_memory_request
-          - name: build_depth_maps_cpu_request
-          - name: build_depth_maps_memory_request
-          - name: build_point_cloud_cpu_request
-          - name: build_point_cloud_memory_request
-          - name: build_mesh_cpu_request
-          - name: build_mesh_memory_request
-          - name: build_dem_orthomosaic_cpu_request
-          - name: build_dem_orthomosaic_memory_request
-          - name: match_photos_secondary_cpu_request
-          - name: match_photos_secondary_memory_request
-          - name: align_cameras_secondary_cpu_request
-          - name: align_cameras_secondary_memory_request
-          - name: finalize_cpu_request
-          - name: finalize_memory_request
-          # S3 imagery download parameters
-          - name: iteration-id
-          - name: imagery-zip-downloads
-            default: "[]"
-          - name: imagery-download-enabled
-            default: "false"
       dag:
         tasks:
-          # Step 0a: Download imagery from S3 (conditional, runs first if enabled)
+          # First task: Load full project config from shared file
+          # All subsequent tasks depend on this and use expressions to extract config values
+          - name: load-config
+            template: load-project-config
+            arguments:
+              parameters:
+                - name: configs-file
+                  value: "{{inputs.parameters.configs-file}}"
+                - name: project-index
+                  value: "{{inputs.parameters.project-index}}"
+
+          # Step 0a: Download imagery from S3 (conditional, runs after config loaded)
           - name: download-imagery
+            depends: "load-config.Succeeded"
             template: download-imagery
-            when: "{{inputs.parameters.imagery-download-enabled}} == true"
+            when: "{{=sprig.fromJson(tasks['load-config'].outputs.result).imagery_download_enabled == 'true'}}"
             arguments:
               parameters:
                 - name: imagery-zip-downloads
-                  value: "{{inputs.parameters.imagery-zip-downloads}}"
+                  value: "{{=toJson(sprig.fromJson(tasks['load-config'].outputs.result).imagery_zip_downloads)}}"
                 - name: iteration-id
-                  value: "{{inputs.parameters.iteration-id}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).iteration_id}}"
 
           # Step 0b: Transform config to resolve __DOWNLOADED__ paths (conditional, depends on download)
           - name: transform-config
             template: transform-config
-            when: "{{inputs.parameters.imagery-download-enabled}} == true"
+            when: "{{=sprig.fromJson(tasks['load-config'].outputs.result).imagery_download_enabled == 'true'}}"
             depends: "download-imagery.Succeeded"
             arguments:
               parameters:
                 - name: config-file
-                  value: "{{inputs.parameters.config-file}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).config}}"
                 - name: iteration-id
-                  value: "{{inputs.parameters.iteration-id}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).iteration_id}}"
                 - name: project-name
                   value: "{{inputs.parameters.project-name}}"
 
           # Step 1: Setup (always runs, CPU only)
-          # Depends on transform-config if downloads enabled, otherwise runs immediately
+          # Depends on transform-config if downloads enabled, otherwise runs after load-config
           - name: setup
             template: metashape-cpu-step
-            depends: "transform-config.Succeeded || transform-config.Skipped"
+            depends: "load-config.Succeeded && (transform-config.Succeeded || transform-config.Skipped)"
             arguments:
               parameters:
                 - name: project-name
                   value: "{{inputs.parameters.project-name}}"
                 - name: config-file
                   # Use transformed config if downloads enabled, otherwise use original config
-                  value: "{{=inputs.parameters['imagery-download-enabled'] == 'true' ? tasks['transform-config'].outputs.parameters['transformed-config-path'] : inputs.parameters['config-file']}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).imagery_download_enabled == 'true' ? tasks['transform-config'].outputs.parameters['transformed-config-path'] : sprig.fromJson(tasks['load-config'].outputs.result).config}}"
                 - name: step
                   value: "setup"
                 - name: iteration-id
-                  value: "{{inputs.parameters.iteration-id}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).iteration_id}}"
                 - name: cpu-request
-                  value: "{{inputs.parameters.setup_cpu_request}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).setup_cpu_request}}"
                 - name: memory-request
-                  value: "{{inputs.parameters.setup_memory_request}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).setup_memory_request}}"
 
           # Step 2: Match Photos (conditional, GPU or CPU based on config)
           - name: match-photos-gpu
             depends: "setup.Succeeded"
-            when: "{{inputs.parameters.match_photos_enabled}} == true && {{inputs.parameters.match_photos_use_gpu}} == true"
+            when: "{{=sprig.fromJson(tasks['load-config'].outputs.result).match_photos_enabled == true && sprig.fromJson(tasks['load-config'].outputs.result).match_photos_use_gpu == true}}"
             template: metashape-gpu-step
             arguments:
               parameters:
                 - name: project-name
                   value: "{{inputs.parameters.project-name}}"
                 - name: config-file
-                  value: "{{=inputs.parameters['imagery-download-enabled'] == 'true' ? tasks['transform-config'].outputs.parameters['transformed-config-path'] : inputs.parameters['config-file']}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).imagery_download_enabled == 'true' ? tasks['transform-config'].outputs.parameters['transformed-config-path'] : sprig.fromJson(tasks['load-config'].outputs.result).config}}"
                 - name: step
                   value: "match_photos"
                 - name: iteration-id
-                  value: "{{inputs.parameters.iteration-id}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).iteration_id}}"
                 - name: gpu-resource
-                  value: "{{inputs.parameters.match_photos_gpu_resource}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).match_photos_gpu_resource}}"
                 - name: gpu-count
-                  value: "{{inputs.parameters.match_photos_gpu_count}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).match_photos_gpu_count}}"
                 - name: cpu-request
-                  value: "{{inputs.parameters.match_photos_cpu_request}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).match_photos_cpu_request}}"
                 - name: memory-request
-                  value: "{{inputs.parameters.match_photos_memory_request}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).match_photos_memory_request}}"
 
           - name: match-photos-cpu
             depends: "setup.Succeeded"
-            when: "{{inputs.parameters.match_photos_enabled}} == true && {{inputs.parameters.match_photos_use_gpu}} == false"
+            when: "{{=sprig.fromJson(tasks['load-config'].outputs.result).match_photos_enabled == true && sprig.fromJson(tasks['load-config'].outputs.result).match_photos_use_gpu == false}}"
             template: metashape-cpu-step
             arguments:
               parameters:
                 - name: project-name
                   value: "{{inputs.parameters.project-name}}"
                 - name: config-file
-                  value: "{{=inputs.parameters['imagery-download-enabled'] == 'true' ? tasks['transform-config'].outputs.parameters['transformed-config-path'] : inputs.parameters['config-file']}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).imagery_download_enabled == 'true' ? tasks['transform-config'].outputs.parameters['transformed-config-path'] : sprig.fromJson(tasks['load-config'].outputs.result).config}}"
                 - name: step
                   value: "match_photos"
                 - name: iteration-id
-                  value: "{{inputs.parameters.iteration-id}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).iteration_id}}"
                 - name: cpu-request
-                  value: "{{inputs.parameters.match_photos_cpu_request}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).match_photos_cpu_request}}"
                 - name: memory-request
-                  value: "{{inputs.parameters.match_photos_memory_request}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).match_photos_memory_request}}"
 
           # Step 3: Align Cameras (conditional, CPU only)
           - name: align-cameras
             depends: "match-photos-gpu.Succeeded || match-photos-gpu.Skipped || match-photos-cpu.Succeeded || match-photos-cpu.Skipped"
-            when: "{{inputs.parameters.align_cameras_enabled}} == true"
+            when: "{{=sprig.fromJson(tasks['load-config'].outputs.result).align_cameras_enabled == true}}"
             template: metashape-cpu-step
             arguments:
               parameters:
                 - name: project-name
                   value: "{{inputs.parameters.project-name}}"
                 - name: config-file
-                  value: "{{=inputs.parameters['imagery-download-enabled'] == 'true' ? tasks['transform-config'].outputs.parameters['transformed-config-path'] : inputs.parameters['config-file']}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).imagery_download_enabled == 'true' ? tasks['transform-config'].outputs.parameters['transformed-config-path'] : sprig.fromJson(tasks['load-config'].outputs.result).config}}"
                 - name: step
                   value: "align_cameras"
                 - name: iteration-id
-                  value: "{{inputs.parameters.iteration-id}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).iteration_id}}"
                 - name: cpu-request
-                  value: "{{inputs.parameters.align_cameras_cpu_request}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).align_cameras_cpu_request}}"
                 - name: memory-request
-                  value: "{{inputs.parameters.align_cameras_memory_request}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).align_cameras_memory_request}}"
 
           # Step 4: Build Depth Maps (conditional, GPU only)
           - name: build-depth-maps
             depends: "align-cameras.Succeeded || align-cameras.Skipped"
-            when: "{{inputs.parameters.build_depth_maps_enabled}} == true"
+            when: "{{=sprig.fromJson(tasks['load-config'].outputs.result).build_depth_maps_enabled == true}}"
             template: metashape-gpu-step
             arguments:
               parameters:
                 - name: project-name
                   value: "{{inputs.parameters.project-name}}"
                 - name: config-file
-                  value: "{{=inputs.parameters['imagery-download-enabled'] == 'true' ? tasks['transform-config'].outputs.parameters['transformed-config-path'] : inputs.parameters['config-file']}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).imagery_download_enabled == 'true' ? tasks['transform-config'].outputs.parameters['transformed-config-path'] : sprig.fromJson(tasks['load-config'].outputs.result).config}}"
                 - name: step
                   value: "build_depth_maps"
                 - name: iteration-id
-                  value: "{{inputs.parameters.iteration-id}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).iteration_id}}"
                 - name: gpu-resource
-                  value: "{{inputs.parameters.build_depth_maps_gpu_resource}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).build_depth_maps_gpu_resource}}"
                 - name: gpu-count
-                  value: "{{inputs.parameters.build_depth_maps_gpu_count}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).build_depth_maps_gpu_count}}"
                 - name: cpu-request
-                  value: "{{inputs.parameters.build_depth_maps_cpu_request}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).build_depth_maps_cpu_request}}"
                 - name: memory-request
-                  value: "{{inputs.parameters.build_depth_maps_memory_request}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).build_depth_maps_memory_request}}"
 
           # Step 5: Build Point Cloud (conditional, CPU only)
           - name: build-point-cloud
             depends: "build-depth-maps.Succeeded || build-depth-maps.Skipped"
-            when: "{{inputs.parameters.build_point_cloud_enabled}} == true"
+            when: "{{=sprig.fromJson(tasks['load-config'].outputs.result).build_point_cloud_enabled == true}}"
             template: metashape-cpu-step
             arguments:
               parameters:
                 - name: project-name
                   value: "{{inputs.parameters.project-name}}"
                 - name: config-file
-                  value: "{{=inputs.parameters['imagery-download-enabled'] == 'true' ? tasks['transform-config'].outputs.parameters['transformed-config-path'] : inputs.parameters['config-file']}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).imagery_download_enabled == 'true' ? tasks['transform-config'].outputs.parameters['transformed-config-path'] : sprig.fromJson(tasks['load-config'].outputs.result).config}}"
                 - name: step
                   value: "build_point_cloud"
                 - name: iteration-id
-                  value: "{{inputs.parameters.iteration-id}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).iteration_id}}"
                 - name: cpu-request
-                  value: "{{inputs.parameters.build_point_cloud_cpu_request}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).build_point_cloud_cpu_request}}"
                 - name: memory-request
-                  value: "{{inputs.parameters.build_point_cloud_memory_request}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).build_point_cloud_memory_request}}"
 
           # Step 6: Build Mesh (conditional, GPU or CPU based on config)
           - name: build-mesh-gpu
             depends: "build-point-cloud.Succeeded || build-point-cloud.Skipped"
-            when: "{{inputs.parameters.build_mesh_enabled}} == true && {{inputs.parameters.build_mesh_use_gpu}} == true"
+            when: "{{=sprig.fromJson(tasks['load-config'].outputs.result).build_mesh_enabled == true && sprig.fromJson(tasks['load-config'].outputs.result).build_mesh_use_gpu == true}}"
             template: metashape-gpu-step
             arguments:
               parameters:
                 - name: project-name
                   value: "{{inputs.parameters.project-name}}"
                 - name: config-file
-                  value: "{{=inputs.parameters['imagery-download-enabled'] == 'true' ? tasks['transform-config'].outputs.parameters['transformed-config-path'] : inputs.parameters['config-file']}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).imagery_download_enabled == 'true' ? tasks['transform-config'].outputs.parameters['transformed-config-path'] : sprig.fromJson(tasks['load-config'].outputs.result).config}}"
                 - name: step
                   value: "build_mesh"
                 - name: iteration-id
-                  value: "{{inputs.parameters.iteration-id}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).iteration_id}}"
                 - name: gpu-resource
-                  value: "{{inputs.parameters.build_mesh_gpu_resource}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).build_mesh_gpu_resource}}"
                 - name: gpu-count
-                  value: "{{inputs.parameters.build_mesh_gpu_count}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).build_mesh_gpu_count}}"
                 - name: cpu-request
-                  value: "{{inputs.parameters.build_mesh_cpu_request}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).build_mesh_cpu_request}}"
                 - name: memory-request
-                  value: "{{inputs.parameters.build_mesh_memory_request}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).build_mesh_memory_request}}"
 
           - name: build-mesh-cpu
             depends: "build-point-cloud.Succeeded || build-point-cloud.Skipped"
-            when: "{{inputs.parameters.build_mesh_enabled}} == true && {{inputs.parameters.build_mesh_use_gpu}} == false"
+            when: "{{=sprig.fromJson(tasks['load-config'].outputs.result).build_mesh_enabled == true && sprig.fromJson(tasks['load-config'].outputs.result).build_mesh_use_gpu == false}}"
             template: metashape-cpu-step
             arguments:
               parameters:
                 - name: project-name
                   value: "{{inputs.parameters.project-name}}"
                 - name: config-file
-                  value: "{{=inputs.parameters['imagery-download-enabled'] == 'true' ? tasks['transform-config'].outputs.parameters['transformed-config-path'] : inputs.parameters['config-file']}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).imagery_download_enabled == 'true' ? tasks['transform-config'].outputs.parameters['transformed-config-path'] : sprig.fromJson(tasks['load-config'].outputs.result).config}}"
                 - name: step
                   value: "build_mesh"
                 - name: iteration-id
-                  value: "{{inputs.parameters.iteration-id}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).iteration_id}}"
                 - name: cpu-request
-                  value: "{{inputs.parameters.build_mesh_cpu_request}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).build_mesh_cpu_request}}"
                 - name: memory-request
-                  value: "{{inputs.parameters.build_mesh_memory_request}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).build_mesh_memory_request}}"
 
           # Step 7: Build DEM/Orthomosaic (conditional, CPU only)
           - name: build-dem-orthomosaic
             depends: "(build-point-cloud.Succeeded || build-point-cloud.Skipped) && (build-mesh-gpu.Succeeded || build-mesh-gpu.Skipped || build-mesh-cpu.Succeeded || build-mesh-cpu.Skipped)"
-            when: "{{inputs.parameters.build_dem_orthomosaic_enabled}} == true"
+            when: "{{=sprig.fromJson(tasks['load-config'].outputs.result).build_dem_orthomosaic_enabled == true}}"
             template: metashape-cpu-step
             arguments:
               parameters:
                 - name: project-name
                   value: "{{inputs.parameters.project-name}}"
                 - name: config-file
-                  value: "{{=inputs.parameters['imagery-download-enabled'] == 'true' ? tasks['transform-config'].outputs.parameters['transformed-config-path'] : inputs.parameters['config-file']}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).imagery_download_enabled == 'true' ? tasks['transform-config'].outputs.parameters['transformed-config-path'] : sprig.fromJson(tasks['load-config'].outputs.result).config}}"
                 - name: step
                   value: "build_dem_orthomosaic"
                 - name: iteration-id
-                  value: "{{inputs.parameters.iteration-id}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).iteration_id}}"
                 - name: cpu-request
-                  value: "{{inputs.parameters.build_dem_orthomosaic_cpu_request}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).build_dem_orthomosaic_cpu_request}}"
                 - name: memory-request
-                  value: "{{inputs.parameters.build_dem_orthomosaic_memory_request}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).build_dem_orthomosaic_memory_request}}"
 
           # Step 8: Match Photos Secondary (conditional, GPU or CPU based on config)
           - name: match-photos-secondary-gpu
             depends: "build-dem-orthomosaic.Succeeded || build-dem-orthomosaic.Skipped"
-            when: "{{inputs.parameters.match_photos_secondary_enabled}} == true && {{inputs.parameters.match_photos_secondary_use_gpu}} == true"
+            when: "{{=sprig.fromJson(tasks['load-config'].outputs.result).match_photos_secondary_enabled == true && sprig.fromJson(tasks['load-config'].outputs.result).match_photos_secondary_use_gpu == true}}"
             template: metashape-gpu-step
             arguments:
               parameters:
                 - name: project-name
                   value: "{{inputs.parameters.project-name}}"
                 - name: config-file
-                  value: "{{=inputs.parameters['imagery-download-enabled'] == 'true' ? tasks['transform-config'].outputs.parameters['transformed-config-path'] : inputs.parameters['config-file']}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).imagery_download_enabled == 'true' ? tasks['transform-config'].outputs.parameters['transformed-config-path'] : sprig.fromJson(tasks['load-config'].outputs.result).config}}"
                 - name: step
                   value: "match_photos_secondary"
                 - name: iteration-id
-                  value: "{{inputs.parameters.iteration-id}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).iteration_id}}"
                 - name: gpu-resource
-                  value: "{{inputs.parameters.match_photos_secondary_gpu_resource}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).match_photos_secondary_gpu_resource}}"
                 - name: gpu-count
-                  value: "{{inputs.parameters.match_photos_secondary_gpu_count}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).match_photos_secondary_gpu_count}}"
                 - name: cpu-request
-                  value: "{{inputs.parameters.match_photos_secondary_cpu_request}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).match_photos_secondary_cpu_request}}"
                 - name: memory-request
-                  value: "{{inputs.parameters.match_photos_secondary_memory_request}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).match_photos_secondary_memory_request}}"
 
           - name: match-photos-secondary-cpu
             depends: "build-dem-orthomosaic.Succeeded || build-dem-orthomosaic.Skipped"
-            when: "{{inputs.parameters.match_photos_secondary_enabled}} == true && {{inputs.parameters.match_photos_secondary_use_gpu}} == false"
+            when: "{{=sprig.fromJson(tasks['load-config'].outputs.result).match_photos_secondary_enabled == true && sprig.fromJson(tasks['load-config'].outputs.result).match_photos_secondary_use_gpu == false}}"
             template: metashape-cpu-step
             arguments:
               parameters:
                 - name: project-name
                   value: "{{inputs.parameters.project-name}}"
                 - name: config-file
-                  value: "{{=inputs.parameters['imagery-download-enabled'] == 'true' ? tasks['transform-config'].outputs.parameters['transformed-config-path'] : inputs.parameters['config-file']}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).imagery_download_enabled == 'true' ? tasks['transform-config'].outputs.parameters['transformed-config-path'] : sprig.fromJson(tasks['load-config'].outputs.result).config}}"
                 - name: step
                   value: "match_photos_secondary"
                 - name: iteration-id
-                  value: "{{inputs.parameters.iteration-id}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).iteration_id}}"
                 - name: cpu-request
-                  value: "{{inputs.parameters.match_photos_secondary_cpu_request}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).match_photos_secondary_cpu_request}}"
                 - name: memory-request
-                  value: "{{inputs.parameters.match_photos_secondary_memory_request}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).match_photos_secondary_memory_request}}"
 
           # Step 9: Align Cameras Secondary (conditional, CPU only)
           - name: align-cameras-secondary
             depends: "match-photos-secondary-gpu.Succeeded || match-photos-secondary-gpu.Skipped || match-photos-secondary-cpu.Succeeded || match-photos-secondary-cpu.Skipped"
-            when: "{{inputs.parameters.align_cameras_secondary_enabled}} == true"
+            when: "{{=sprig.fromJson(tasks['load-config'].outputs.result).align_cameras_secondary_enabled == true}}"
             template: metashape-cpu-step
             arguments:
               parameters:
                 - name: project-name
                   value: "{{inputs.parameters.project-name}}"
                 - name: config-file
-                  value: "{{=inputs.parameters['imagery-download-enabled'] == 'true' ? tasks['transform-config'].outputs.parameters['transformed-config-path'] : inputs.parameters['config-file']}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).imagery_download_enabled == 'true' ? tasks['transform-config'].outputs.parameters['transformed-config-path'] : sprig.fromJson(tasks['load-config'].outputs.result).config}}"
                 - name: step
                   value: "align_cameras_secondary"
                 - name: iteration-id
-                  value: "{{inputs.parameters.iteration-id}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).iteration_id}}"
                 - name: cpu-request
-                  value: "{{inputs.parameters.align_cameras_secondary_cpu_request}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).align_cameras_secondary_cpu_request}}"
                 - name: memory-request
-                  value: "{{inputs.parameters.align_cameras_secondary_memory_request}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).align_cameras_secondary_memory_request}}"
 
           # Step 10: Finalize (always runs, CPU only)
           - name: finalize
@@ -547,15 +467,15 @@ spec:
                 - name: project-name
                   value: "{{inputs.parameters.project-name}}"
                 - name: config-file
-                  value: "{{=inputs.parameters['imagery-download-enabled'] == 'true' ? tasks['transform-config'].outputs.parameters['transformed-config-path'] : inputs.parameters['config-file']}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).imagery_download_enabled == 'true' ? tasks['transform-config'].outputs.parameters['transformed-config-path'] : sprig.fromJson(tasks['load-config'].outputs.result).config}}"
                 - name: step
                   value: "finalize"
                 - name: iteration-id
-                  value: "{{inputs.parameters.iteration-id}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).iteration_id}}"
                 - name: cpu-request
-                  value: "{{inputs.parameters.finalize_cpu_request}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).finalize_cpu_request}}"
                 - name: memory-request
-                  value: "{{inputs.parameters.finalize_memory_request}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).finalize_memory_request}}"
 
           # Upload task (runs after finalize completes)
           - name: rclone-upload-task
@@ -566,7 +486,7 @@ spec:
                 - name: project-name
                   value: "{{inputs.parameters.project-name}}"
                 - name: iteration-id
-                  value: "{{inputs.parameters.iteration-id}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).iteration_id}}"
                 - name: photogrammetry-config-subfolder
                   value: "{{inputs.parameters.photogrammetry-config-subfolder}}"
 
@@ -579,7 +499,7 @@ spec:
                 - name: project-name
                   value: "{{inputs.parameters.project-name}}"
                 - name: iteration-id
-                  value: "{{inputs.parameters.iteration-id}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).iteration_id}}"
                 - name: photogrammetry-config-subfolder
                   value: "{{inputs.parameters.photogrammetry-config-subfolder}}"
 
@@ -590,7 +510,7 @@ spec:
             arguments:
               parameters:
                 - name: iteration-id
-                  value: "{{inputs.parameters.iteration-id}}"
+                  value: "{{=sprig.fromJson(tasks['load-config'].outputs.result).iteration_id}}"
 
     ## Here we define what each step does in 'process-project-workflow' step
 


### PR DESCRIPTION
This reduces Argo parameter size limits by using minimal references for project configurations. This gets around an Argo size constraint on parameters passed between steps.

Copilot summary:

This pull request updates the photogrammetry workflow to avoid hitting Argo's parameter size limits by changing how project configuration data is passed between workflow steps. Instead of passing full configuration objects through workflow parameters, the full configs are written to a shared file and only minimal references (index and project name) are passed via parameters. Each project step then loads its config from the shared file at runtime. The changes touch both the `determine_datasets.py` utility and the Argo workflow YAML.

**Workflow parameter handling improvements:**

* Updated `determine_datasets.py` to accept an optional `output_file_path` argument. When provided, the script writes the full configs to this file and outputs only minimal references (index and project name) to stdout, reducing the risk of exceeding Argo's parameter size limits. [[1]](diffhunk://#diff-42fd11bde193ba19c6ad391b2c920b7bb899290a48ecafc0aca6b3d1897336c8L10-R20) [[2]](diffhunk://#diff-42fd11bde193ba19c6ad391b2c920b7bb899290a48ecafc0aca6b3d1897336c8L429-R436) [[3]](diffhunk://#diff-42fd11bde193ba19c6ad391b2c920b7bb899290a48ecafc0aca6b3d1897336c8R445-R446) [[4]](diffhunk://#diff-42fd11bde193ba19c6ad391b2c920b7bb899290a48ecafc0aca6b3d1897336c8L466-R505) [[5]](diffhunk://#diff-42fd11bde193ba19c6ad391b2c920b7bb899290a48ecafc0aca6b3d1897336c8R518-R530)
* Modified the Argo workflow YAML (`photogrammetry-workflow-stepbased.yaml`) so that only minimal references are passed to downstream steps via `withParam`, and the full configs are loaded from the shared file at runtime. This change is reflected in both the step definitions and the documentation comments. [[1]](diffhunk://#diff-80bd0ee6390f2d0d88f3a93c1b8fb302bc6d3208cc5823edf3f4a9aa459401e1R72-L168) [[2]](diffhunk://#diff-80bd0ee6390f2d0d88f3a93c1b8fb302bc6d3208cc5823edf3f4a9aa459401e1R113-R116)

**Documentation and usage updates:**

* Improved usage instructions and docstrings in `determine_datasets.py` to clarify the new artifact-based mode and its benefits for large batch runs. [[1]](diffhunk://#diff-42fd11bde193ba19c6ad391b2c920b7bb899290a48ecafc0aca6b3d1897336c8L10-R20) [[2]](diffhunk://#diff-42fd11bde193ba19c6ad391b2c920b7bb899290a48ecafc0aca6b3d1897336c8R445-R446) [[3]](diffhunk://#diff-42fd11bde193ba19c6ad391b2c920b7bb899290a48ecafc0aca6b3d1897336c8R518-R530)
* Updated workflow YAML comments to document the new approach for handling large config payloads.