### PR TITLE
Increase geograypher memory to 54GB

### DIFF
--- a/argo-workflows/species-prediction-workflow.yaml
+++ b/argo-workflows/species-prediction-workflow.yaml
@@ -467,9 +467,9 @@ spec:
         resources:
           requests:
             cpu: 8
-            memory: "24Gi"
+            memory: "54Gi"
           limits:
-            memory: "24Gi"
+            memory: "54Gi"
         command: ["python",
             "-m", "geograypher.entrypoints.render_labels",
             "--mesh-file", "{{inputs.parameters.mesh-file}}",


### PR DESCRIPTION
This ran successfully on all the Yuba datasets.