### PR TITLE
Add a registration workflow

### DIFF
--- a/argo-workflows/README.md
+++ b/argo-workflows/README.md
@@ -9,3 +9,16 @@ The workflow performs the follow series of steps
 - **Chipping**: Chip out the images corresponding to the view of each tree and mask the background. This structure parallels the structure of the input data, with one folder of chips for each input image. Within that folder, chips are named based on the tree `unique_ID` that generated them.
 - **Prediction**: The species and live/dead predictions are generated using `MMPretrain` and the per-chip predictions are saved to a `.json` file.
 - **Aggregation and merging**: The final step is to use the per-chip predictions to vote on the class per tree. Then this information is merged into the original geospatial data product as a new column. This step is computationally very fast, and is only distinct from the prediction step because the `MMPretrain` container does not have the required dependencies to load geospatial files.
+
+### Registring Field Trees to Drone Products
+There may be a spatial miss-alignment between the field reference data and the drone products. This is primarily driven by differences in the GPS bias between the surveys. The `register-field-trees-to-CHM.yaml` workflow can be used to estimate a shift which best aligns the field data with the drone products, specifically by using the CHM. This approach determines the shift which produces the best correlation between the field trees heights and the corresponding locations on the CHM. This is done in a two-stage coarse-to-fine manner.
+
+The workflow takes as input field trees and field plot bounds from the shared data drive and downloads drone mission metadata and CHM products from `S3`. For each overlapping pair of field plot and drone mission, the output is a `.csv` file containing the shift which would best align the field trees to the corresponding CHM, with associated quality metrics. This file follows the convention `js2s3:ofo-public/drone/{missions dir}/{mission ID}/{photogrammetry ID}/ground-reference-shifts/{plot ID}_{mission ID}_ground-reference-shift.csv`
+
+The workflow contains the following steps
+- The drone mission bounds metadata is downloaded from `S3`.
+- The overlap is computed between the drone mission bounds and the field plot bounds. In cases where a drone mission has two rows in the bounds metadata (such as an oblique-nadir composite mission) the intersection between the two is used. A drone mission and plot are considered a pair if the field plot is fully within the drone mission bounds or the field plot overlaps the drone mission by greater than 0.25ha.
+- For each pair:
+    - The CHM file is downloaded from `S3`.
+    - Registration is run using the [this](https://github.com/open-forest-observatory/tree-registration-and-matching/blob/main/tree_registration_and_matching/entrypoints/register_trees_to_CHM.py) tree-registration-and-matching entrypoint.
+    - The shift file is uploaded to `S3` and the intermediate data products are deleted.

--- a/argo-workflows/register-field-trees-to-CHM.yaml
+++ b/argo-workflows/register-field-trees-to-CHM.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
-  generateName: register-field-trees-to-CHM-workflow-
+  generateName: register-field-trees-to-chm-workflow-
 spec:
   serviceAccountName: argo
   entrypoint: main
@@ -210,7 +210,7 @@ spec:
               crs=gpd.read_file(metadata_files[0]).crs,
           )
 
-          # Overlay mission footprints with field plot bounds
+          # Overlay mission footprints with field trees
           overlay = gpd.overlay(mission_metadata, field_trees)
           pairs = overlay[["mission_id", "plot_id"]].drop_duplicates()
 

--- a/argo-workflows/register-field-trees-to-CHM.yaml
+++ b/argo-workflows/register-field-trees-to-CHM.yaml
@@ -215,9 +215,11 @@ spec:
 
           # Read all downloaded mission metadata files
           metadata_files = list(metadata_folder.rglob("*.gpkg"))
+          mission_metadata = [gpd.read_file(f) for f in metadata_files]
+
           mission_metadata = gpd.GeoDataFrame(
-              pd.concat([gpd.read_file(f) for f in metadata_files]),
-              crs=gpd.read_file(metadata_files[0]).crs,
+              pd.concat(mission_metadata),
+              crs=mission_metadata[0].crs,
           )
 
           # Once mission metadata has been read, delete the folder of metadata

--- a/argo-workflows/register-field-trees-to-CHM.yaml
+++ b/argo-workflows/register-field-trees-to-CHM.yaml
@@ -113,7 +113,7 @@ spec:
                 - name: input-trees-file
                   value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}_field-trees.gpkg"
                 - name: CHM-file
-                  value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}/{{inputs.parameters.mission-id}}_chm-ptcloud.tif"
+                  value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}/{{inputs.parameters.mission-id}}_chm-mesh.tif"
                 - name: output-shift-file
                   value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}/{{inputs.parameters.plot-id}}_{{inputs.parameters.mission-id}}_shift.csv"
 
@@ -281,7 +281,7 @@ spec:
             LOCAL_DIR="{{inputs.parameters.local-dir}}"
             S3_SRC="s3:{{inputs.parameters.s3-bucket}}/{{inputs.parameters.s3-data-folder}}/${MISSION_ID}/{{workflow.parameters.PHOTOGRAMMETRY_ID}}/full/"
             # TODO this could also be updated to include the tree top files
-            INCLUDES="--include ${MISSION_ID}_chm-ptcloud.tif"
+            INCLUDES="--include ${MISSION_ID}_chm-mesh.tif"
 
             mkdir -p "$LOCAL_DIR"
 
@@ -290,7 +290,7 @@ spec:
               --transfers 1 --checkers 1 --retries 5 --retries-sleep=15s \
               --stats 15s --stats-log-level NOTICE
 
-            CHM_FILE="${LOCAL_DIR}/${MISSION_ID}_chm-ptcloud.tif"
+            CHM_FILE="${LOCAL_DIR}/${MISSION_ID}_chm-mesh.tif"
 
             # Verify all expected files were downloaded
             if [ ! -f "$CHM_FILE" ]; then

--- a/argo-workflows/register-field-trees-to-CHM.yaml
+++ b/argo-workflows/register-field-trees-to-CHM.yaml
@@ -118,7 +118,7 @@ spec:
                 - name: CHM-file
                   value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}/{{inputs.parameters.mission-id}}_chm-mesh.tif"
                 - name: output-shift-file
-                  value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}/{{inputs.parameters.plot-id}}_{{inputs.parameters.mission-id}}_shift.csv"
+                  value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}_shift.csv"
 
           - name: upload-shift-file
             template: rclone-upload-template
@@ -132,7 +132,7 @@ spec:
                 - name: temp-dir
                   value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}"
                 - name: shift-file
-                  value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}/{{inputs.parameters.plot-id}}_{{inputs.parameters.mission-id}}_shift.csv"
+                  value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}_shift.csv"
 ## Definitions of individual steps (templates)
     # Download mission-metadata gpkg files from S3 to the shared volume.
     - name: download-mission-metadata
@@ -325,10 +325,10 @@ spec:
 
           json.dump(datasets, sys.stdout)
 
-    # Download mission composite photogrammetry products from S3 to the shared volume.
+    # Download photogrammetry products (for a single or composite mission) from S3 to the shared volume.
     # Returns a JSON dict of local file paths via outputs.parameters.local-files.
     # Keys: camera, chm, dtm, mesh. Fails if any expected file is missing.
-    # S3 source path: <s3-bucket>/drone/mission-composites_01/<mission-id>/full/<mission-id>
+    # S3 source path: <s3-bucket>/<S3_DATA_FOLDER>/<mission-id>/full/<mission-id>
     - name: download-input-data
       inputs:
         parameters:
@@ -460,7 +460,7 @@ spec:
             set -euo pipefail
             SRC="{{inputs.parameters.shift-file}}"
             TEMP_DIR="{{inputs.parameters.temp-dir}}"
-            DST="s3:{{workflow.parameters.S3_BUCKET_PUBLIC}}/{{workflow.parameters.S3_DATA_FOLDER}}/{{inputs.parameters.mission-id}}/{{workflow.parameters.PHOTOGRAMMETRY_ID}}/ground-reference-shifts/{{inputs.parameters.plot-id}}_{{inputs.parameters.mission-id}}_ground-reference-shift.csv"
+            DST="s3:{{workflow.parameters.S3_BUCKET_PUBLIC}}/{{workflow.parameters.S3_DATA_FOLDER}}/{{inputs.parameters.mission-id}}/{{workflow.parameters.PHOTOGRAMMETRY_ID}}/ground-reference-shifts/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}_ground-reference-shift.csv"
 
             echo "[rclone] Uploading selected files from $SRC -> $DST"
             rclone copyto "$SRC" "$DST" \

--- a/argo-workflows/register-field-trees-to-CHM.yaml
+++ b/argo-workflows/register-field-trees-to-CHM.yaml
@@ -457,7 +457,7 @@ spec:
             set -euo pipefail
             SRC="{{inputs.parameters.shift-file}}"
             TEMP_DIR="{{inputs.parameters.temp-dir}}"
-            DST="s3:{{workflow.parameters.S3_BUCKET_PUBLIC}}/{{workflow.parameters.S3_DATA_FOLDER}}/{{inputs.parameters.mission-id}}/{{workflow.parameters.PHOTOGRAMMETRY_ID}}/{{inputs.parameters.plot-id}}_{{inputs.parameters.mission-id}}_ground-reference-shift.csv"
+            DST="s3:{{workflow.parameters.S3_BUCKET_PUBLIC}}/{{workflow.parameters.S3_DATA_FOLDER}}/{{inputs.parameters.mission-id}}/{{workflow.parameters.PHOTOGRAMMETRY_ID}}/ground-reference-shifts/{{inputs.parameters.plot-id}}_{{inputs.parameters.mission-id}}_ground-reference-shift.csv"
 
             echo "[rclone] Uploading selected files from $SRC -> $DST"
             rclone copyto "$SRC" "$DST" \

--- a/argo-workflows/register-field-trees-to-CHM.yaml
+++ b/argo-workflows/register-field-trees-to-CHM.yaml
@@ -113,7 +113,7 @@ spec:
                 - name: input-trees-file
                   value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}_field-trees.gpkg"
                 - name: CHM-file
-                  value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}/{{inputs.parameters.mission-id}}_chm-ptcloud.tif"
+                  value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}/{{inputs.parameters.mission-id}}_chm-mesh.tif"
                 - name: output-shift-file
                   value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}/{{inputs.parameters.plot-id}}_{{inputs.parameters.mission-id}}_shift.csv"
 
@@ -261,13 +261,16 @@ spec:
           shutil.rmtree(metadata_folder)
 
           # Some composite missions have different polygons per constituent flight, so find the intersection
-          # of both
+          # of both. The mission_ID should be the concatenation of the constituent mission IDs,
+          # separated by an underscore
           mission_metadata = [
               gpd.GeoDataFrame(
-                  {
-                      "geometry": shapely.intersection_all(gdf.geometry.to_list()),
-                      "mission_id": gdf["mission_id"],
-                  },
+                  [
+                    {
+                        "geometry": shapely.intersection_all(gdf.geometry.to_list()),
+                        "mission_id": "_".join(gdf["mission_id"].to_list()),
+                    }
+                  ],
                   crs=gdf.crs,
               )
               for gdf in mission_metadata
@@ -351,7 +354,7 @@ spec:
             LOCAL_DIR="{{inputs.parameters.local-dir}}"
             S3_SRC="s3:{{inputs.parameters.s3-bucket}}/{{inputs.parameters.s3-data-folder}}/${MISSION_ID}/{{workflow.parameters.PHOTOGRAMMETRY_ID}}/full/"
             # TODO this could also be updated to include the tree top files
-            INCLUDES="--include ${MISSION_ID}_chm-ptcloud.tif"
+            INCLUDES="--include ${MISSION_ID}_chm-mesh.tif"
 
             mkdir -p "$LOCAL_DIR"
 
@@ -360,7 +363,7 @@ spec:
               --transfers 1 --checkers 1 --retries 5 --retries-sleep=15s \
               --stats 15s --stats-log-level NOTICE
 
-            CHM_FILE="${LOCAL_DIR}/${MISSION_ID}_chm-ptcloud.tif"
+            CHM_FILE="${LOCAL_DIR}/${MISSION_ID}_chm-mesh.tif"
 
             # Verify all expected files were downloaded
             if [ ! -f "$CHM_FILE" ]; then

--- a/argo-workflows/register-field-trees-to-CHM.yaml
+++ b/argo-workflows/register-field-trees-to-CHM.yaml
@@ -465,7 +465,7 @@ spec:
               --s3-upload-cutoff 200Mi --s3-chunk-size 100Mi --s3-upload-concurrency 4 \
               --stats 15s --stats-log-level NOTICE
 
-            echo "[rclone] Upload successful for {{inputs.parameters.dataset-name}}"
+            echo "[rclone] Upload successful for plot ID: {{inputs.parameters.plot-id}}, mission ID: {{inputs.parameters.mission-id}}"
 
             echo "[cleanup] Removing local dataset directory: $TEMP_DIR"
             rm -rf "$TEMP_DIR"

--- a/argo-workflows/register-field-trees-to-CHM.yaml
+++ b/argo-workflows/register-field-trees-to-CHM.yaml
@@ -45,9 +45,9 @@ spec:
       - name: S3_BUCKET_PUBLIC
         value: "ofo-public"
       - name: S3_DATA_FOLDER
-        value: "drone/mission-composites_01"
+        value: "drone/missions_03"
       - name: PHOTOGRAMMETRY_ID
-        value: "photogrammetry_01"
+        value: "photogrammetry_03"
       # All per-dataset temp products and outputs are saved under:
       # TEMP_FOLDER/{{workflow.name}}/{{dataset-name}}/
       - name: TEMP_FOLDER
@@ -372,7 +372,7 @@ spec:
             set -euo pipefail
             SRC="{{inputs.parameters.registered-trees-file}}"
             TEMP_DIR="{{inputs.parameters.temp-dir}}"
-            DST="s3:{{workflow.parameters.S3_BUCKET_PUBLIC}}/{{workflow.parameters.S3_DATA_FOLDER}}/{{inputs.parameters.dataset-name}}/{{workflow.parameters.S3_PHOTOGRAMMETRY_SUBFOLDER}}/{{inputs.parameters.dataset-name}}_registered_field_trees.gpkg"
+            DST="s3:{{workflow.parameters.S3_BUCKET_PUBLIC}}/{{workflow.parameters.S3_DATA_FOLDER}}/{{inputs.parameters.dataset-name}}/{{workflow.parameters.PHOTOGRAMMETRY_ID}}/{{inputs.parameters.dataset-name}}_registered_field_trees.gpkg"
 
             echo "[rclone] Uploading selected files from $SRC -> $DST"
             rclone copy "$SRC" "$DST" \

--- a/argo-workflows/register-field-trees-to-CHM.yaml
+++ b/argo-workflows/register-field-trees-to-CHM.yaml
@@ -198,8 +198,11 @@ spec:
         source: |
           import json
           import sys
+          import shapely
           import shutil
+          import pyproj
           from pathlib import Path
+
 
           import geopandas as gpd
           import pandas as pd
@@ -209,6 +212,43 @@ spec:
           plot_bounds_file = Path("{{workflow.parameters.FIELD_PLOT_BOUNDS_FILE}}")
           temp_folder = Path("{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}")
 
+          # The threshold in square meters for inclusion, even if the field plot isn't fully contained within
+          # the mission footprint
+          PLOT_SIZE_THRESHOLD = 2500
+
+
+          def get_projected_CRS(lat, lon, assume_western_hem=True):
+              if assume_western_hem and lon > 0:
+                  lon = -lon
+              # https://gis.stackexchange.com/questions/190198/how-to-get-appropriate-crs-for-a-position-specified-in-lat-lon-coordinates
+              epgs_code = 32700 - round((45 + lat) / 90) * 100 + round((183 + lon) / 6)
+              crs = pyproj.CRS.from_epsg(epgs_code)
+              return crs
+
+
+          def ensure_projected_CRS(geodata: gpd.GeoDataFrame):
+              """Returns a projected geodataframe from the provided geodataframe by converting it to
+              ESPG:4326 (if not already) and determining the projected CRS from the point
+              coordinates.
+              Args:
+                  geodata (gpd.GeoDataGrame): Original geodataframe that is potentially unprojected
+              Returns:
+                  gpd.GeoDataGrame: projected geodataframe
+              """
+              # If CRS is projected return immediately
+              if geodata.crs.is_projected:
+                  return geodata
+
+              # If CRS is geographic and not long-lat, convert it to long-lat
+              if geodata.crs.is_geographic and geodata.crs != pyproj.CRS.from_epsg(4326):
+                  geodata = geodata.to_crs(pyproj.CRS.from_epsg(4326))
+
+              # Convert geographic long-lat CRS to projected CRS
+              point = geodata["geometry"].iloc[0].centroid
+              geometric_crs = get_projected_CRS(lon=point.x, lat=point.y)
+              return geodata.to_crs(geometric_crs)
+
+
           # Read field trees
           field_trees = gpd.read_file(field_trees_file)
           plot_bounds = gpd.read_file(plot_bounds_file)
@@ -217,20 +257,50 @@ spec:
           metadata_files = list(metadata_folder.rglob("*.gpkg"))
           mission_metadata = [gpd.read_file(f) for f in metadata_files]
 
+          # Once mission metadata has been read, delete it
+          shutil.rmtree(metadata_folder)
+
+          # Some composite missions have different polygons per constituent flight, so find the intersection
+          # of both
+          mission_metadata = [
+              gpd.GeoDataFrame(
+                  {
+                      "geometry": shapely.intersection_all(gdf.geometry.to_list()),
+                      "mission_id": gdf["mission_id"],
+                  },
+                  crs=gdf.crs,
+              )
+              for gdf in mission_metadata
+          ]
+
           mission_metadata = gpd.GeoDataFrame(
               pd.concat(mission_metadata),
               crs=mission_metadata[0].crs,
           )
 
-          # Once mission metadata has been read, delete the folder of metadata
-          shutil.rmtree(metadata_folder)
+          # Convert mission metadata to projected CRS
+          mission_metadata = ensure_projected_CRS(mission_metadata)
 
-          # Convert mission metadata to the same CRS as the field trees
+          # Convert mission metadata to the same CRS as the mission_metadata
           plot_bounds = plot_bounds.to_crs(mission_metadata.crs)
 
-          # Overlay mission footprints with field trees
-          overlay = gpd.overlay(mission_metadata, plot_bounds)
-          pairs = overlay[["mission_id", "plot_id"]].drop_duplicates()
+          # Add a column noting the original area of the plots
+          plot_bounds["original_plot_area"] = plot_bounds.geometry.area
+
+          # Overlay mission footprints with field tree bounds
+          pairs = gpd.overlay(
+              mission_metadata[["mission_id", "geometry"]],
+              plot_bounds,
+          )
+          # Subset to relevant columns
+          pairs = pairs[["mission_id", "plot_id", "original_plot_area", "geometry"]]
+
+          # Retain pairs where the overlapping area is greater than the threshold or the field plot is fully
+          # contained within the mission footprint
+          pairs = pairs[
+              (pairs.geometry.area > PLOT_SIZE_THRESHOLD)
+              | (pairs.geometry.area == pairs["original_plot_area"])
+          ]
 
           # For each (mission, plot) pair, subset field trees to that plot and save to disk
           datasets = []

--- a/argo-workflows/register-field-trees-to-CHM.yaml
+++ b/argo-workflows/register-field-trees-to-CHM.yaml
@@ -114,19 +114,22 @@ spec:
                   value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}_field-trees.gpkg"
                 - name: CHM-file
                   value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}/{{inputs.parameters.mission-id}}_chm-ptcloud.tif"
-                - name: output-trees-file
-                  value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}_registered-trees.gpkg"
-          - name: upload-registered-trees
+                - name: output-shift-file
+                  value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}/{{inputs.parameters.plot-id}}_{{inputs.parameters.mission-id}}_shift.csv"
+
+          - name: upload-shift-file
             template: rclone-upload-template
             depends: "register-trees.Succeeded"
             arguments:
               parameters:
-                - name: dataset-name
-                  value: "{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}"
+                - name: plot-id
+                  value: "{{inputs.parameters.plot-id}}"
+                - name: mission-id
+                  value: "{{inputs.parameters.mission-id}}"
                 - name: temp-dir
                   value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}"
-                - name: registered-trees-file
-                  value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}_registered-trees.gpkg"
+                - name: shift-file
+                  value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}/{{inputs.parameters.plot-id}}_{{inputs.parameters.mission-id}}_shift.csv"
 ## Definitions of individual steps (templates)
     # Download mission-metadata gpkg files from S3 to the shared volume.
     - name: download-mission-metadata
@@ -335,7 +338,7 @@ spec:
         parameters:
           - name: input-trees-file
           - name: CHM-file
-          - name: output-trees-file
+          - name: output-shift-file
       container:
         image: ghcr.io/open-forest-observatory/tree-registration-and-matching:{{workflow.parameters.TRAM_IMAGE_TAG}}
         volumeMounts:
@@ -353,8 +356,8 @@ spec:
                   "{{inputs.parameters.input-trees-file}}",
                   "--CHM-file",
                   "{{inputs.parameters.CHM-file}}",
-                  "--output-shifted-trees",
-                  "{{inputs.parameters.output-trees-file}}",
+                  "--output-shift-summary",
+                  "{{inputs.parameters.output-shift-file}}",
                 ]
 
     # --------- RCLONE UPLOAD ---------
@@ -362,8 +365,9 @@ spec:
     - name: rclone-upload-template
       inputs:
         parameters:
-          - name: registered-trees-file
-          - name: dataset-name
+          - name: plot-id
+          - name: mission-id
+          - name: shift-file
           - name: temp-dir
       nodeSelector:
         feature.node.kubernetes.io/workload-type: cpu
@@ -376,9 +380,9 @@ spec:
         args:
           - |
             set -euo pipefail
-            SRC="{{inputs.parameters.registered-trees-file}}"
+            SRC="{{inputs.parameters.shift-file}}"
             TEMP_DIR="{{inputs.parameters.temp-dir}}"
-            DST="s3:{{workflow.parameters.S3_BUCKET_PUBLIC}}/{{workflow.parameters.S3_DATA_FOLDER}}/{{inputs.parameters.dataset-name}}/{{workflow.parameters.PHOTOGRAMMETRY_ID}}/{{inputs.parameters.dataset-name}}_registered_field_trees.gpkg"
+            DST="s3:{{workflow.parameters.S3_BUCKET_PUBLIC}}/{{workflow.parameters.S3_DATA_FOLDER}}/{{inputs.parameters.mission-id}}/{{workflow.parameters.PHOTOGRAMMETRY_ID}}/{{inputs.parameters.plot-id}}_{{inputs.parameters.mission-id}}_ground-reference-shift.csv"
 
             echo "[rclone] Uploading selected files from $SRC -> $DST"
             rclone copy "$SRC" "$DST" \

--- a/argo-workflows/register-field-trees-to-CHM.yaml
+++ b/argo-workflows/register-field-trees-to-CHM.yaml
@@ -460,9 +460,9 @@ spec:
             DST="s3:{{workflow.parameters.S3_BUCKET_PUBLIC}}/{{workflow.parameters.S3_DATA_FOLDER}}/{{inputs.parameters.mission-id}}/{{workflow.parameters.PHOTOGRAMMETRY_ID}}/{{inputs.parameters.plot-id}}_{{inputs.parameters.mission-id}}_ground-reference-shift.csv"
 
             echo "[rclone] Uploading selected files from $SRC -> $DST"
-            rclone copy "$SRC" "$DST" \
+            rclone copyto "$SRC" "$DST" \
               --transfers 1 --checkers 1 --retries 5 --retries-sleep=15s \
-              --s3-upload-cutoff 200Mi --s3-chunk-size 100Mi --s3-upload-concurrency 4 \
+              --s3-upload-cutoff 200Mi --s3-chunk-size 100Mi \
               --stats 15s --stats-log-level NOTICE
 
             echo "[rclone] Upload successful for plot ID: {{inputs.parameters.plot-id}}, mission ID: {{inputs.parameters.mission-id}}"

--- a/argo-workflows/register-field-trees-to-CHM.yaml
+++ b/argo-workflows/register-field-trees-to-CHM.yaml
@@ -41,17 +41,20 @@ spec:
   # These parameters can be referenced throughout the workflow templates using {{workflow.parameters.<name>}}
   arguments:
     parameters:
-      # S3 bucket for public/final outputs (mission composites, species predictions)
+      # S3 bucket to obtain drone mission bounds metadata and CHM files from
       - name: S3_BUCKET_PUBLIC
         value: "ofo-public"
+      # Which folder to use on S3
       - name: S3_DATA_FOLDER
         value: "drone/missions_03"
+      # Which photogrammetry run to use
       - name: PHOTOGRAMMETRY_ID
         value: "photogrammetry_03"
       # All per-dataset temp products and outputs are saved under:
       # TEMP_FOLDER/{{workflow.name}}/{{dataset-name}}/
       - name: TEMP_FOLDER
         value: "/data/argo-output/temp-dir"
+      # Image from tree-detection-and-matching repo to use.
       - name: TRAM_IMAGE_TAG
         value: "main"
       # Path on the shared volume to the single field trees file, which will be subset by plot_id.

--- a/argo-workflows/register-field-trees-to-CHM.yaml
+++ b/argo-workflows/register-field-trees-to-CHM.yaml
@@ -41,7 +41,6 @@ spec:
   # These parameters can be referenced throughout the workflow templates using {{workflow.parameters.<name>}}
   arguments:
     parameters:
-      - name: DATASETS_FILE
       # S3 bucket for public/final outputs (mission composites, species predictions)
       - name: S3_BUCKET_PUBLIC
         value: "ofo-public"
@@ -55,9 +54,8 @@ spec:
         value: "/data/argo-output/temp-dir"
       - name: TRAM_IMAGE_TAG
         value: "main"
-      # Folder on the shared volume containing field tree point files.
-      # Each file should be named <dataset-name>.gpkg
-      - name: FIELD_TREES_FOLDER
+      # Path on the shared volume to the single field trees file, which will be subset by plot_id.
+      - name: FIELD_TREES_FILE
 
   # Defining where to read raw drone imagery data and write out imagery products to `/ofo-share`
   volumes:
@@ -66,26 +64,29 @@ spec:
         claimName: ceph-share-rw-pvc2
 
   templates:
-    # The 'main' template reads the datasets file and fans out to process each dataset in parallel.
+    # The 'main' template determines datasets and fans out to process each in parallel.
     - name: main
       steps:
+        - - name: download-mission-metadata
+            template: download-mission-metadata
         - - name: determine-datasets
             template: determine-datasets
         - - name: process-datasets
             template: process-dataset-workflow
             arguments:
               parameters:
-                - name: dataset-name
-                  value: "{{item}}"
+                - name: mission-id
+                  value: "{{item.mission-id}}"
+                - name: plot-id
+                  value: "{{item.plot-id}}"
             # Continue processing remaining datasets even if one fails
             withParam: "{{steps.determine-datasets.outputs.result}}"
 
     - name: process-dataset-workflow
       inputs:
         parameters:
-          # The dataset name represents the composite of two individual mission IDs, represented as
-          # two six-digit strings separated by an underscore (e.g. 000001_000002).
-          - name: dataset-name
+          - name: mission-id
+          - name: plot-id
       dag:
         # failFast=false ensures other datasets continue if this one fails
         failFast: false
@@ -95,48 +96,139 @@ spec:
             arguments:
               parameters:
                 - name: mission-id
-                  value: "{{inputs.parameters.dataset-name}}"
+                  value: "{{inputs.parameters.mission-id}}"
                 - name: s3-bucket
                   value: "{{workflow.parameters.S3_BUCKET_PUBLIC}}"
                 - name: s3-data-folder
                   value: "{{workflow.parameters.S3_DATA_FOLDER}}"
                 - name: local-dir
-                  value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.dataset-name}}"
+                  value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}"
           - name: register-trees
             template: register-trees
             depends: "download-input-data.Succeeded"
             arguments:
               parameters:
                 - name: input-trees-file
-                  value: "{{workflow.parameters.FIELD_TREES_FOLDER}}/{{inputs.parameters.dataset-name}}.gpkg"
+                  value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}_field-trees.gpkg"
                 - name: CHM-file
-                  value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.dataset-name}}/{{inputs.parameters.dataset-name}}_chm-ptcloud.tif"
+                  value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}/{{inputs.parameters.mission-id}}_chm-ptcloud.tif"
                 - name: output-trees-file
-                  value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.dataset-name}}/{{inputs.parameters.dataset-name}}_registered_trees.gpkg"
+                  value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}_registered-trees.gpkg"
           - name: upload-registered-trees
             template: rclone-upload-template
             depends: "register-trees.Succeeded"
             arguments:
               parameters:
                 - name: dataset-name
-                  value: "{{inputs.parameters.dataset-name}}"
+                  value: "{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}"
                 - name: temp-dir
-                  value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.dataset-name}}"
+                  value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}"
                 - name: registered-trees-file
-                  value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.dataset-name}}/{{inputs.parameters.dataset-name}}_registered_trees.gpkg"
+                  value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}/{{inputs.parameters.mission-id}}_{{inputs.parameters.plot-id}}_registered-trees.gpkg"
 ## Definitions of individual steps (templates)
-    # Parse the newline-separated datasets file into a JSON array of dataset names
-    - name: determine-datasets
-      script:
-        image: python:3.9
+    # Download mission-metadata gpkg files from S3 to the shared volume.
+    - name: download-mission-metadata
+      container:
+        image: rclone/rclone:sha-7a53f24
         volumeMounts:
           - name: data
             mountPath: /data
-        command: ["python3"]
+        command: ["/bin/sh", "-lc"]
+        args:
+          - |
+            set -euo pipefail
+            DST="{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/mission-metadata"
+            mkdir -p "$DST"
+            rclone copy "s3:{{workflow.parameters.S3_BUCKET_PUBLIC}}/{{workflow.parameters.S3_DATA_FOLDER}}" \
+              "$DST" \
+              --include "*_mission-metadata.gpkg" \
+              --transfers 4 --checkers 4 --retries 5 --retries-sleep=15s \
+              --stats 15s --stats-log-level NOTICE
+        resources:
+          requests:
+            cpu: 1
+            memory: "2Gi"
+          limits:
+            memory: "4Gi"
+        env:
+          - name: RCLONE_CONFIG_S3_TYPE
+            value: "s3"
+          - name: RCLONE_CONFIG_S3_PROVIDER
+            valueFrom:
+              secretKeyRef:
+                name: s3-credentials
+                key: provider
+          - name: RCLONE_CONFIG_S3_ENDPOINT
+            valueFrom:
+              secretKeyRef:
+                name: s3-credentials
+                key: endpoint
+          - name: RCLONE_CONFIG_S3_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: s3-credentials
+                key: access_key
+          - name: RCLONE_CONFIG_S3_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: s3-credentials
+                key: secret_key
+
+    # Overlay mission footprints with field plot bounds to determine which (mission, plot) pairs
+    # to process. Subsets the field trees file by plot_id for each pair and saves to disk.
+    # Outputs a JSON array of {"mission-id": ..., "plot-id": ...} objects.
+    - name: determine-datasets
+      script:
+        image: uhoosborne/geopandas@sha256:42bdd13882321a2647668446dae9ee1a8d76f2ac95aa8c3cb4e8eacadd5070d9
+        volumeMounts:
+          - name: data
+            mountPath: /data
+        resources:
+          requests:
+            cpu: 1
+            memory: "4Gi"
+          limits:
+            memory: "8Gi"
+        command: ["python"]
         source: |
           import json, sys
-          with open("{{workflow.parameters.DATASETS_FILE}}", "r") as f:
-              datasets = [line.strip() for line in f if line.strip()]
+          import geopandas as gpd
+          import pandas as pd
+          from pathlib import Path
+
+          metadata_folder = Path("{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/mission-metadata")
+          field_trees_file = Path("{{workflow.parameters.FIELD_TREES_FILE}}")
+          temp_folder = Path("{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}")
+
+          # Read field trees
+          field_trees = gpd.read_file(field_trees_file)
+
+          # Read all downloaded mission metadata files
+          metadata_files = list(metadata_folder.rglob("*.gpkg"))
+          mission_metadata = gpd.GeoDataFrame(
+              pd.concat([gpd.read_file(f) for f in metadata_files]),
+              crs=gpd.read_file(metadata_files[0]).crs,
+          )
+
+          # Overlay mission footprints with field plot bounds
+          overlay = gpd.overlay(mission_metadata, field_trees)
+          pairs = overlay[["mission_id", "plot_id"]].drop_duplicates()
+
+          # For each (mission, plot) pair, subset field trees to that plot and save to disk
+          datasets = []
+          for _, row in pairs.iterrows():
+              mission_id = str(row["mission_id"])
+              plot_id = str(row["plot_id"])
+              dataset_name = f"{mission_id}_{plot_id}"
+
+              subset = field_trees[field_trees["plot_id"] == row["plot_id"]]
+
+              out_dir = temp_folder / dataset_name
+              out_dir.mkdir(parents=True, exist_ok=True)
+              subset.to_file(out_dir / f"{dataset_name}_field-trees.gpkg")
+
+              datasets.append({"mission-id": mission_id, "plot-id": plot_id})
+
           json.dump(datasets, sys.stdout)
 
     # Download mission composite photogrammetry products from S3 to the shared volume.

--- a/argo-workflows/register-field-trees-to-CHM.yaml
+++ b/argo-workflows/register-field-trees-to-CHM.yaml
@@ -56,6 +56,8 @@ spec:
         value: "main"
       # Path on the shared volume to the single field trees file, which will be subset by plot_id.
       - name: FIELD_TREES_FILE
+      # Path on the shared volume to the plot bounds file, representing the extent of each survey
+      - name: FIELD_PLOT_BOUNDS_FILE
 
   # Defining where to read raw drone imagery data and write out imagery products to `/ofo-share`
   volumes:
@@ -198,10 +200,12 @@ spec:
 
           metadata_folder = Path("{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/mission-metadata")
           field_trees_file = Path("{{workflow.parameters.FIELD_TREES_FILE}}")
+          plot_bounds_file = Path("{{workflow.parameters.FIELD_PLOT_BOUNDS_FILE}}")
           temp_folder = Path("{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}")
 
           # Read field trees
           field_trees = gpd.read_file(field_trees_file)
+          plot_bounds = gpd.read_file(plot_bounds_file)
 
           # Read all downloaded mission metadata files
           metadata_files = list(metadata_folder.rglob("*.gpkg"))
@@ -210,8 +214,11 @@ spec:
               crs=gpd.read_file(metadata_files[0]).crs,
           )
 
+          # Convert mission metadata to the same CRS as the field trees
+          plot_bounds = plot_bounds.to_crs(mission_metadata.crs)
+
           # Overlay mission footprints with field trees
-          overlay = gpd.overlay(mission_metadata, field_trees)
+          overlay = gpd.overlay(mission_metadata, plot_bounds)
           pairs = overlay[["mission_id", "plot_id"]].drop_duplicates()
 
           # For each (mission, plot) pair, subset field trees to that plot and save to disk

--- a/argo-workflows/register-field-trees-to-CHM.yaml
+++ b/argo-workflows/register-field-trees-to-CHM.yaml
@@ -193,10 +193,13 @@ spec:
             memory: "8Gi"
         command: ["python"]
         source: |
-          import json, sys
+          import json
+          import sys
+          import shutil
+          from pathlib import Path
+
           import geopandas as gpd
           import pandas as pd
-          from pathlib import Path
 
           metadata_folder = Path("{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/mission-metadata")
           field_trees_file = Path("{{workflow.parameters.FIELD_TREES_FILE}}")
@@ -213,6 +216,9 @@ spec:
               pd.concat([gpd.read_file(f) for f in metadata_files]),
               crs=gpd.read_file(metadata_files[0]).crs,
           )
+
+          # Once mission metadata has been read, delete the folder of metadata
+          shutil.rmtree(metadata_folder)
 
           # Convert mission metadata to the same CRS as the field trees
           plot_bounds = plot_bounds.to_crs(mission_metadata.crs)

--- a/argo-workflows/register-field-trees-to-CHM.yaml
+++ b/argo-workflows/register-field-trees-to-CHM.yaml
@@ -1,0 +1,317 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: register-field-trees-to-CHM-workflow-
+spec:
+  serviceAccountName: argo
+  entrypoint: main
+  # Max concurrent projects to process in parallel. Edit this value directly to change.
+  # (Argo doesn't support parameter substitution for integer fields like parallelism)
+  parallelism: 18
+
+  # Set imagePullPolicy for all containers in the workflow
+  podSpecPatch: |
+    containers:
+      - name: main
+        imagePullPolicy: Always
+
+  # Affinity rules for workflow pods:
+  # 1. nodeAffinity: Schedule on non-GPU nodes by default (GPU tasks override with affinity: {})
+  # 2. podAffinity: Prefer nodes with other running workflow pods to minimize autoscaler evictions
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: nvidia.com/gpu.present
+                operator: DoesNotExist
+    podAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: workflows.argoproj.io/completed
+                  operator: In
+                  values:
+                    - "false"
+            topologyKey: kubernetes.io/hostname
+
+  # A list of input parameters available to the workflow at runtime.
+  # These parameters can be referenced throughout the workflow templates using {{workflow.parameters.<name>}}
+  arguments:
+    parameters:
+      - name: DATASETS_FILE
+      # S3 bucket for public/final outputs (mission composites, species predictions)
+      - name: S3_BUCKET_PUBLIC
+        value: "ofo-public"
+      - name: S3_DATA_FOLDER
+        value: "drone/mission-composites_01"
+      - name: PHOTOGRAMMETRY_ID
+        value: "photogrammetry_01"
+      # All per-dataset temp products and outputs are saved under:
+      # TEMP_FOLDER/{{workflow.name}}/{{dataset-name}}/
+      - name: TEMP_FOLDER
+        value: "/data/argo-output/temp-dir"
+      - name: TRAM_IMAGE_TAG
+        value: "main"
+      # Folder on the shared volume containing field tree point files.
+      # Each file should be named <dataset-name>.gpkg
+      - name: FIELD_TREES_FOLDER
+
+  # Defining where to read raw drone imagery data and write out imagery products to `/ofo-share`
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: ceph-share-rw-pvc2
+
+  templates:
+    # The 'main' template reads the datasets file and fans out to process each dataset in parallel.
+    - name: main
+      steps:
+        - - name: determine-datasets
+            template: determine-datasets
+        - - name: process-datasets
+            template: process-dataset-workflow
+            arguments:
+              parameters:
+                - name: dataset-name
+                  value: "{{item}}"
+            # Continue processing remaining datasets even if one fails
+            withParam: "{{steps.determine-datasets.outputs.result}}"
+
+    - name: process-dataset-workflow
+      inputs:
+        parameters:
+          # The dataset name represents the composite of two individual mission IDs, represented as
+          # two six-digit strings separated by an underscore (e.g. 000001_000002).
+          - name: dataset-name
+      dag:
+        # failFast=false ensures other datasets continue if this one fails
+        failFast: false
+        tasks:
+          - name: download-input-data
+            template: download-input-data
+            arguments:
+              parameters:
+                - name: mission-id
+                  value: "{{inputs.parameters.dataset-name}}"
+                - name: s3-bucket
+                  value: "{{workflow.parameters.S3_BUCKET_PUBLIC}}"
+                - name: s3-data-folder
+                  value: "{{workflow.parameters.S3_DATA_FOLDER}}"
+                - name: local-dir
+                  value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.dataset-name}}"
+          - name: register-trees
+            template: register-trees
+            depends: "download-input-data.Succeeded"
+            arguments:
+              parameters:
+                - name: input-trees-file
+                  value: "{{workflow.parameters.FIELD_TREES_FOLDER}}/{{inputs.parameters.dataset-name}}.gpkg"
+                - name: CHM-file
+                  value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.dataset-name}}/{{inputs.parameters.dataset-name}}_chm-ptcloud.tif"
+                - name: output-trees-file
+                  value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.dataset-name}}/{{inputs.parameters.dataset-name}}_registered_trees.gpkg"
+          - name: upload-registered-trees
+            template: rclone-upload-template
+            depends: "register-trees.Succeeded"
+            arguments:
+              parameters:
+                - name: dataset-name
+                  value: "{{inputs.parameters.dataset-name}}"
+                - name: temp-dir
+                  value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.dataset-name}}"
+                - name: registered-trees-file
+                  value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.dataset-name}}/{{inputs.parameters.dataset-name}}_registered_trees.gpkg"
+## Definitions of individual steps (templates)
+    # Parse the newline-separated datasets file into a JSON array of dataset names
+    - name: determine-datasets
+      script:
+        image: python:3.9
+        volumeMounts:
+          - name: data
+            mountPath: /data
+        command: ["python3"]
+        source: |
+          import json, sys
+          with open("{{workflow.parameters.DATASETS_FILE}}", "r") as f:
+              datasets = [line.strip() for line in f if line.strip()]
+          json.dump(datasets, sys.stdout)
+
+    # Download mission composite photogrammetry products from S3 to the shared volume.
+    # Returns a JSON dict of local file paths via outputs.parameters.local-files.
+    # Keys: camera, chm, dtm, mesh. Fails if any expected file is missing.
+    # S3 source path: <s3-bucket>/drone/mission-composites_01/<mission-id>/full/<mission-id>
+    - name: download-input-data
+      inputs:
+        parameters:
+          - name: mission-id
+          - name: s3-bucket
+            value: "ofo-public"
+          - name: s3-data-folder
+            value: "{{workflow.parameters.S3_DATA_FOLDER}}"
+          - name: local-dir
+            value: "{{workflow.parameters.TEMP_FOLDER}}/{{workflow.name}}/{{inputs.parameters.mission-id}}"
+      outputs:
+        parameters:
+          - name: local-files
+            valueFrom:
+              path: /tmp/file-paths.json
+      container:
+        image: rclone/rclone:sha-7a53f24
+        volumeMounts:
+          - name: data
+            mountPath: /data
+        command: ["/bin/sh", "-lc"]
+        args:
+          - |
+            set -euo pipefail
+            MISSION_ID="{{inputs.parameters.mission-id}}"
+            LOCAL_DIR="{{inputs.parameters.local-dir}}"
+            S3_SRC="s3:{{inputs.parameters.s3-bucket}}/{{inputs.parameters.s3-data-folder}}/${MISSION_ID}/{{workflow.parameters.PHOTOGRAMMETRY_ID}}/full/"
+            # TODO this could also be updated to include the tree top files
+            INCLUDES="--include ${MISSION_ID}_chm-ptcloud.tif"
+
+            mkdir -p "$LOCAL_DIR"
+
+            echo "[rclone] Downloading $S3_SRC -> $LOCAL_DIR"
+            rclone copy "$S3_SRC" "$LOCAL_DIR" $INCLUDES \
+              --transfers 1 --checkers 1 --retries 5 --retries-sleep=15s \
+              --stats 15s --stats-log-level NOTICE
+
+            CHM_FILE="${LOCAL_DIR}/${MISSION_ID}_chm-ptcloud.tif"
+
+            # Verify all expected files were downloaded
+            if [ ! -f "$CHM_FILE" ]; then
+              echo "[download] ERROR: Expected file not found: $CHM_FILE"
+              exit 1
+            fi
+            echo "Verified CHM download"
+
+            # Build JSON dict of downloaded file paths
+            printf '{"chm":"%s"}' "$CHM_FILE" \
+              > /tmp/file-paths.json
+
+            echo "[download] File paths written to /tmp/file-paths.json"
+        resources:
+          requests:
+            cpu: 1
+            memory: "2Gi"
+          limits:
+            memory: "4Gi"
+        env:
+          - name: RCLONE_CONFIG_S3_TYPE
+            value: "s3"
+          - name: RCLONE_CONFIG_S3_PROVIDER
+            valueFrom:
+              secretKeyRef:
+                name: s3-credentials
+                key: provider
+          - name: RCLONE_CONFIG_S3_ENDPOINT
+            valueFrom:
+              secretKeyRef:
+                name: s3-credentials
+                key: endpoint
+          - name: RCLONE_CONFIG_S3_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: s3-credentials
+                key: access_key
+          - name: RCLONE_CONFIG_S3_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: s3-credentials
+                key: secret_key
+
+
+    - name: register-trees
+      inputs:
+        parameters:
+          - name: input-trees-file
+          - name: CHM-file
+          - name: output-trees-file
+      container:
+        image: ghcr.io/open-forest-observatory/tree-registration-and-matching:{{workflow.parameters.TRAM_IMAGE_TAG}}
+        volumeMounts:
+          - name: data
+            mountPath: /data
+        resources:
+          requests:
+            cpu: "2"
+            memory: "8Gi"
+        command: [
+                  "python",
+                  "-m",
+                  "tree_registration_and_matching.entrypoints.register_trees_to_CHM",
+                  "--tree-points-file",
+                  "{{inputs.parameters.input-trees-file}}",
+                  "--CHM-file",
+                  "{{inputs.parameters.CHM-file}}",
+                  "--output-shifted-trees",
+                  "{{inputs.parameters.output-trees-file}}",
+                ]
+
+    # --------- RCLONE UPLOAD ---------
+    # Uploads the two final output files to S3, then cleans up the local dataset directory.
+    - name: rclone-upload-template
+      inputs:
+        parameters:
+          - name: registered-trees-file
+          - name: dataset-name
+          - name: temp-dir
+      nodeSelector:
+        feature.node.kubernetes.io/workload-type: cpu
+      container:
+        image: rclone/rclone:latest
+        volumeMounts:
+          - name: data
+            mountPath: /data
+        command: ["/bin/sh", "-lc"]
+        args:
+          - |
+            set -euo pipefail
+            SRC="{{inputs.parameters.registered-trees-file}}"
+            TEMP_DIR="{{inputs.parameters.temp-dir}}"
+            DST="s3:{{workflow.parameters.S3_BUCKET_PUBLIC}}/{{workflow.parameters.S3_DATA_FOLDER}}/{{inputs.parameters.dataset-name}}/{{workflow.parameters.S3_PHOTOGRAMMETRY_SUBFOLDER}}/{{inputs.parameters.dataset-name}}_registered_field_trees.gpkg"
+
+            echo "[rclone] Uploading selected files from $SRC -> $DST"
+            rclone copy "$SRC" "$DST" \
+              --transfers 1 --checkers 1 --retries 5 --retries-sleep=15s \
+              --s3-upload-cutoff 200Mi --s3-chunk-size 100Mi --s3-upload-concurrency 4 \
+              --stats 15s --stats-log-level NOTICE
+
+            echo "[rclone] Upload successful for {{inputs.parameters.dataset-name}}"
+
+            echo "[cleanup] Removing local dataset directory: $TEMP_DIR"
+            rm -rf "$TEMP_DIR"
+            echo "[cleanup] Done"
+        resources:
+          requests:
+            cpu: 500m
+            memory: "256Mi"
+          limits:
+            memory: "1Gi"
+        env:
+          - name: RCLONE_CONFIG_S3_TYPE
+            value: "s3"
+          - name: RCLONE_CONFIG_S3_PROVIDER
+            valueFrom:
+              secretKeyRef:
+                name: s3-credentials
+                key: provider
+          - name: RCLONE_CONFIG_S3_ENDPOINT
+            valueFrom:
+              secretKeyRef:
+                name: s3-credentials
+                key: endpoint
+          - name: RCLONE_CONFIG_S3_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: s3-credentials
+                key: access_key
+          - name: RCLONE_CONFIG_S3_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: s3-credentials
+                key: secret_key


### PR DESCRIPTION
This adds a new workflow to register field trees to the drone-derived CHMs. Algorithmically, this relies on an approach from [tree registration and matching](https://github.com/open-forest-observatory/tree-registration-and-matching) which computes the correlation between the field-derived heights of the tree and the corresponding location on the CHM, across a grid of candidate shifts.

This workflow takes as input the location of photogrammetry products on `S3` as well as the path to the field trees and plot bounds on the mounted volume. Using this information, the overlapping plots and drone missions are obtained. Each pair of field trees and CHM is registered independently and a file summarizing the optimal shift and the quality of the obtained registration is produced. Then, this summary file is uploaded back to `S3` (with format `{missions folder}/{mission id}/{photogrammetry id}/ground-reference-shifts/{plot id}_{mission id}_ground-reference-shift.csv`.