### PR TITLE
Add preprocessing entrypoint

### DIFF
--- a/docker-photogrammetry-postprocessing/postprocessing/postprocess.py
+++ b/docker-photogrammetry-postprocessing/postprocessing/postprocess.py
@@ -178,7 +178,7 @@ def _crop_rgb_orthomosaic(src, geometries, output_filename):
 
 
 def crop_raster_save_cog(
-    raster_filepath, output_filename, mission_polygon, output_path
+    raster_filepath: str | Path, output_filepath: str | Path, mission_polygon: gpd.GeoDataFrame
 ):
     """
     Crop raster to mission polygon boundary and save as Cloud Optimized GeoTIFF (COG).
@@ -187,11 +187,13 @@ def crop_raster_save_cog(
     For other rasters, uses standard nodata value handling.
 
     Args:
-        raster_filepath: Path to input raster file
-        output_filename: Output filename
-        mission_polygon: GeoDataFrame containing mission boundary polygon
-        output_path: Base output directory path
+        raster_filepath (str | Path): Path to input raster file
+        output_filepath (str | Path): Path to save output file after cropping
+        mission_polygon (GeoDataFrame): GeoDataFrame containing mission boundary polygon
     """
+    # Ensure output_filepath is a Path object
+    output_filepath = Path(output_filepath)
+
     # Read raster
     with rasterio.open(raster_filepath) as src:
         # Reproject mission polygon to match raster CRS
@@ -206,7 +208,7 @@ def crop_raster_save_cog(
         colorinterp = None
         if _is_rgb_orthomosaic(src):
             cropped_data, cropped_transform, profile, colorinterp = (
-                _crop_rgb_orthomosaic(src, geometries, output_filename)
+                _crop_rgb_orthomosaic(src, geometries, output_filepath.name)
             )
         else:
             # Standard handling for non-RGB rasters (elevation data, etc.)
@@ -219,7 +221,7 @@ def crop_raster_save_cog(
                 nodata_value = -32767
                 output_dtype = "int16"
                 print(
-                    f"  Warning: {output_filename} has no nodata defined. "
+                    f"  Warning: {output_filepath.name} has no nodata defined. "
                     "Promoting uint8 to int16 to enable nodata masking."
                 )
             else:
@@ -255,15 +257,14 @@ def crop_raster_save_cog(
                 cropped_data = cropped_data.astype(output_dtype)
 
         # Write output
-        output_file_path = os.path.join(output_path, "full", output_filename)
-        with rasterio.open(output_file_path, "w", **profile) as dst:
+        with rasterio.open(output_filepath, "w", **profile) as dst:
             dst.write(cropped_data)
 
             # Set color interpretation for RGBA so GIS software recognizes alpha band
             if colorinterp is not None:
                 dst.colorinterp = colorinterp
 
-    print(f"  Saved COG: {output_filename}")
+    print(f"  Saved COG: {output_filepath}")
 
 
 def make_chm(dsm_filepath, dtm_filepath):

--- a/docker-photogrammetry-postprocessing/postprocessing/postprocess.py
+++ b/docker-photogrammetry-postprocessing/postprocessing/postprocess.py
@@ -504,10 +504,10 @@ def postprocess_photogrammetry_containerized(
             try:
                 crop_raster_save_cog(
                     raster_filepath=row["full_path"],
-                    output_filename=row["postprocessed_filename"],
+                    output_filepath=postprocessed_path / row["postprocessed_filename"],
                     mission_polygon=mission_polygon,
-                    output_path=postprocessed_path,
                 )
+
             except Exception as e:
                 print(
                     f"  Warning: Failed to process {row['photogrammetry_output_filename']}: {e}"

--- a/docker-photogrammetry-postprocessing/postprocessing/preprocess.py
+++ b/docker-photogrammetry-postprocessing/postprocessing/preprocess.py
@@ -23,7 +23,7 @@ def preprocess(
         dataset_dir: The directory where the preprocessed files will be saved.
         local_files: JSON string of local file paths (ortho, chm, shift, field_trees, plot_bounds).
         min_tree_height: Minimum tree height (meters) used to filter field trees.
-        output_path: Path to write the preprocessed file paths JSON. Default to a /tmp location, if not provided.
+        output_path: Path to write the preprocessed file paths JSON. Default to None.
     """
     field_trees_path = local_files["field_trees"]
     plot_bounds_path = local_files["plot_bounds"]

--- a/docker-photogrammetry-postprocessing/postprocessing/preprocess.py
+++ b/docker-photogrammetry-postprocessing/postprocessing/preprocess.py
@@ -4,8 +4,54 @@ from pathlib import Path
 
 import geopandas as gpd
 import pandas as pd
+import numpy as np
 
 from postprocessing import crop_raster_save_cog, transform_to_local_utm
+
+
+# Copied from https://github.com/open-forest-observatory/tree-registration-and-matching to avoid dependency.
+def ensure_height_is_present(
+    ground_reference_trees: gpd.GeoDataFrame, height_col: str = "height"
+) -> gpd.GeoDataFrame:
+    """
+    Ensure that every row has a height attribute with the following proceedure:
+    * If height is present, this is used
+    * Then, fill in with height_allometric
+    * Then, fill in with allometric height derived from DBH
+    * Finally, drop any trees without a height
+
+    Args:
+        ground_reference_trees (gpd.GeoDataFrame): The trees to add height to
+        height_col (str): Which column represents the height. Defaults to "height".
+
+    Returns:
+        gpd.GeoDataFrame: The ground reference trees with every row having the height attributes
+    """
+    # First replace any missing height values with pre-computed allometric values
+    nan_height = ground_reference_trees.height.isna()
+    ground_reference_trees.loc[nan_height, height_col] = ground_reference_trees[
+        nan_height
+    ].height_allometric.astype(float)
+
+    # For any remaining missing height values that have DBH, use an allometric equation to compute
+    # the height
+    nan_height = ground_reference_trees[height_col].isna()
+    # These parameters were fit on paired height, DBH data from Western conifers dataset.
+    allometric_height_func = lambda x: 1.3 + np.exp(
+        -0.3136489123372108 + 0.84623571 * np.log(x)
+    )
+    # Compute the allometric height and assign it
+    allometric_height = allometric_height_func(
+        ground_reference_trees[nan_height].dbh.to_numpy()
+    )
+    ground_reference_trees.loc[nan_height, height_col] = allometric_height
+
+    # Filter out any trees that still don't have height
+    ground_reference_trees = ground_reference_trees[
+        ~ground_reference_trees[height_col].isna()
+    ]
+
+    return ground_reference_trees
 
 
 def preprocess(
@@ -68,6 +114,9 @@ def preprocess(
     )
     # Convert back to the original CRS
     field_trees = field_trees.to_crs(original_crs)
+
+    # Ensure height is present, filling in allometric estimates where needed.
+    field_trees = ensure_height_is_present(field_trees)
 
     # Filter out short trees based on the provided minimum tree height.
     n_before = len(field_trees)

--- a/docker-photogrammetry-postprocessing/postprocessing/preprocess.py
+++ b/docker-photogrammetry-postprocessing/postprocessing/preprocess.py
@@ -1,0 +1,177 @@
+import argparse
+import json
+from pathlib import Path
+
+import geopandas as gpd
+import pandas as pd
+
+from postprocessing import crop_raster_save_cog, transform_to_local_utm
+
+
+def preprocess(
+    plot_id: str,
+    dataset_dir: Path,
+    local_files: dict,
+    min_tree_height: float,
+    output_path: Path = Path("/tmp/preprocessed-file-paths.json"),
+):
+    field_trees_path = local_files["field_trees"]
+    plot_bounds_path = local_files["plot_bounds"]
+    shift_file_path = local_files["shift"]
+    ortho_path = local_files["ortho"]
+    chm_path = local_files["chm"]
+
+    # Destination path to save the preprocessed field trees
+    ground_truth_path = dataset_dir / "ground_truth.gpkg"
+
+    # Create the "full" directory for cropped rasters if it doesn't exist. This is where
+    # crop_raster_save_cog writes to {output_path}/full/{filename}
+    (dataset_dir / "full").mkdir(parents=True, exist_ok=True)
+
+    # Load field trees
+    field_trees = gpd.read_file(field_trees_path)
+    field_trees = field_trees[field_trees["plot_id"] == plot_id].copy()
+    print(f"[preprocess] {len(field_trees)} trees for plot_id={plot_id}")
+
+    if len(field_trees) == 0:
+        raise ValueError(f"No trees found for plot_id={plot_id} in {field_trees_path}")
+
+    # Load plot bounds
+    plot_bounds = gpd.read_file(plot_bounds_path)
+    plot_bounds = plot_bounds[plot_bounds["plot_id"] == plot_id].copy()
+
+    if len(plot_bounds) == 0:
+        raise ValueError(f"No plot bounds found for plot_id={plot_id} in {plot_bounds_path}")
+
+    # Load the shift information
+    shift_df = pd.read_csv(shift_file_path)
+    shift_x = float(shift_df["estimated_shift_x"].iloc[0])
+    shift_y = float(shift_df["estimated_shift_y"].iloc[0])
+    shift_crs = shift_df["shift_CRS"].iloc[0]
+
+    # Convert field trees to the shift CRS
+    original_crs = field_trees.crs
+    field_trees  = field_trees.to_crs(shift_crs)
+    # Apply the shift to the field trees
+    field_trees["geometry"] = field_trees.geometry.translate(
+        xoff=shift_x, yoff=shift_y
+    )
+    # Convert back to the original CRS
+    field_trees = field_trees.to_crs(original_crs)
+
+    # Filter out short trees based on the provided minimum tree height.
+    n_before = len(field_trees)
+    field_trees = field_trees[field_trees["height"] >= min_tree_height]
+    print(f"[preprocess] Height filter: {n_before} -> {len(field_trees)} trees")
+
+    # Save the shifted field trees as the ground truth for this plot.
+    # This is what will be used for matching and evaluation.
+    ground_truth_path.parent.mkdir(parents=True, exist_ok=True)
+    field_trees.to_file(ground_truth_path)
+    print(f"[preprocess] Saved ground_truth.gpkg: {ground_truth_path}")
+
+    # Shift the plot bounds by the same amount as the trees,
+    # so that they are aligned with the shifted trees and rasters.
+    bounds_original_crs = plot_bounds.crs
+    plot_bounds = plot_bounds.to_crs(shift_crs)
+    plot_bounds["geometry"] = plot_bounds.geometry.translate(
+        xoff=shift_x, yoff=shift_y
+    )
+    plot_bounds = plot_bounds.to_crs(bounds_original_crs)
+
+    # Save the shifted plot bounds, which will be used for cropping the rasters and
+    # for evaluation in a later step.
+    shifted_plot_bounds_path = dataset_dir / "shifted_plot_bounds.gpkg"
+    plot_bounds.to_file(shifted_plot_bounds_path)
+    print(f"[preprocess] Saved shifted_plot_bounds.gpkg: {shifted_plot_bounds_path}")
+
+    plot_bounds_utm = transform_to_local_utm(plot_bounds)
+    plot_bounds_buffered = plot_bounds_utm.copy()
+    # Buffer the plot bounds by 20 meters
+    plot_bounds_buffered["geometry"] = plot_bounds_utm.geometry.buffer(20)
+    plot_bounds_buffered = plot_bounds_buffered.to_crs(bounds_original_crs)
+
+    print(f"[preprocess] Cropping orthomosaic to plot bounds")
+    crop_raster_save_cog(
+        raster_filepath=ortho_path,
+        output_filename="cropped_ortho.tif",
+        mission_polygon=plot_bounds_buffered,
+        output_path=str(dataset_dir),
+    )
+
+    print(f"[preprocess] Cropping CHM to plot bounds")
+    crop_raster_save_cog(
+        raster_filepath=chm_path,
+        output_filename="cropped_chm.tif",
+        mission_polygon=plot_bounds_buffered,
+        output_path=str(dataset_dir),
+    )
+
+    cropped_ortho = dataset_dir / "full" / "cropped_ortho.tif"
+    cropped_chm = dataset_dir / "full" / "cropped_chm.tif"
+
+    # Check that the cropped files were created successfully
+    for f in [cropped_ortho, cropped_chm]:
+        if not f.exists():
+            raise RuntimeError(f"[preprocess] ERROR: expected cropped file not found: {f}")
+
+    print(f"[preprocess] Cropped ortho: {cropped_ortho}")
+    print(f"[preprocess] Cropped CHM:   {cropped_chm}")
+
+    preprocessed_files = {
+        **local_files,
+        "ortho": str(cropped_ortho),
+        "chm":   str(cropped_chm),
+    }
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w") as f:
+        json.dump(preprocessed_files, f)
+
+    print("[preprocess] preprocessed-file-paths.json written.")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Preprocess field trees and rasters for a single plot."
+    )
+    parser.add_argument(
+        "--plot-id",
+        required=True,
+        help="Plot ID to subset field trees and plot bounds.",
+    )
+    parser.add_argument(
+        "--dataset-dir",
+        required=True,
+        type=Path,
+        help="Directory for dataset outputs.",
+    )
+    parser.add_argument(
+        "--local-files",
+        required=True,
+        help="JSON string of local file paths (ortho, chm, shift, field_trees, plot_bounds).",
+    )
+    parser.add_argument(
+        "--min-tree-height",
+        required=True,
+        type=float,
+        help="Minimum tree height (meters) used to filter field trees.",
+    )
+    parser.add_argument(
+        "--output-path",
+        type=Path,
+        default=Path("/tmp/preprocessed-file-paths.json"),
+        help="Path to write the preprocessed file paths JSON.",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    preprocess(
+        plot_id=args.plot_id,
+        dataset_dir=args.dataset_dir,
+        local_files=json.loads(args.local_files),
+        min_tree_height=args.min_tree_height,
+        output_path=args.output_path,
+    )

--- a/docker-photogrammetry-postprocessing/postprocessing/preprocess.py
+++ b/docker-photogrammetry-postprocessing/postprocessing/preprocess.py
@@ -13,8 +13,18 @@ def preprocess(
     dataset_dir: Path,
     local_files: dict,
     min_tree_height: float,
-    output_path: Path = Path("/tmp/preprocessed-file-paths.json"),
+    output_path: Path | None = None,
 ):
+    """
+    Preprocesses the field trees and rasters for a single plot. 
+
+    Args:
+        plot_id: The plot ID to subset the field trees and plot bounds.
+        dataset_dir: The directory where the preprocessed files will be saved.
+        local_files: JSON string of local file paths (ortho, chm, shift, field_trees, plot_bounds).
+        min_tree_height: Minimum tree height (meters) used to filter field trees.
+        output_path: Path to write the preprocessed file paths JSON. Default to a /tmp location, if not provided.
+    """
     field_trees_path = local_files["field_trees"]
     plot_bounds_path = local_files["plot_bounds"]
     shift_file_path = local_files["shift"]
@@ -107,6 +117,7 @@ def preprocess(
         output_path=str(dataset_dir),
     )
 
+    # crop_raster_save_cog saves the outputs in a full/ subdirectory, so we construct those paths.
     cropped_ortho = dataset_dir / "full" / "cropped_ortho.tif"
     cropped_chm = dataset_dir / "full" / "cropped_chm.tif"
 
@@ -118,17 +129,17 @@ def preprocess(
     print(f"[preprocess] Cropped ortho: {cropped_ortho}")
     print(f"[preprocess] Cropped CHM:   {cropped_chm}")
 
-    preprocessed_files = {
-        **local_files,
-        "ortho": str(cropped_ortho),
-        "chm":   str(cropped_chm),
-    }
-
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_path, "w") as f:
-        json.dump(preprocessed_files, f)
-
-    print("[preprocess] preprocessed-file-paths.json written.")
+    # Save updated file paths to a JSON for use in next steps. Primarily for Argo use.
+    if output_path is not None:
+        preprocessed_files = {
+            **local_files,
+            "ortho": str(cropped_ortho),
+            "chm":   str(cropped_chm),
+        }
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(output_path, "w") as f:
+            json.dump(preprocessed_files, f)
+        print("[preprocess] preprocessed-file-paths.json written.")
 
 
 def parse_args():
@@ -160,8 +171,8 @@ def parse_args():
     parser.add_argument(
         "--output-path",
         type=Path,
-        default=Path("/tmp/preprocessed-file-paths.json"),
-        help="Path to write the preprocessed file paths JSON.",
+        default=None,
+        help="Path to write the preprocessed file paths JSON. If omitted, the file is not written.",
     )
     return parser.parse_args()
 

--- a/docker-photogrammetry-postprocessing/postprocessing/preprocess.py
+++ b/docker-photogrammetry-postprocessing/postprocessing/preprocess.py
@@ -80,10 +80,6 @@ def preprocess(
     # Destination path to save the preprocessed field trees
     ground_truth_path = dataset_dir / "ground_truth.gpkg"
 
-    # Create the "full" directory for cropped rasters if it doesn't exist. This is where
-    # crop_raster_save_cog writes to {output_path}/full/{filename}
-    (dataset_dir / "full").mkdir(parents=True, exist_ok=True)
-
     # Load field trees
     field_trees = gpd.read_file(field_trees_path)
     field_trees = field_trees[field_trees["plot_id"] == plot_id].copy()
@@ -151,24 +147,20 @@ def preprocess(
     plot_bounds_buffered = plot_bounds_buffered.to_crs(bounds_original_crs)
 
     print(f"[preprocess] Cropping orthomosaic to plot bounds")
+    cropped_ortho = dataset_dir / "cropped_ortho.tif"
     crop_raster_save_cog(
         raster_filepath=ortho_path,
-        output_filename="cropped_ortho.tif",
+        output_filepath=cropped_ortho,
         mission_polygon=plot_bounds_buffered,
-        output_path=str(dataset_dir),
     )
 
     print(f"[preprocess] Cropping CHM to plot bounds")
+    cropped_chm = dataset_dir / "cropped_chm.tif"
     crop_raster_save_cog(
         raster_filepath=chm_path,
-        output_filename="cropped_chm.tif",
+        output_filepath=cropped_chm,
         mission_polygon=plot_bounds_buffered,
-        output_path=str(dataset_dir),
     )
-
-    # crop_raster_save_cog saves the outputs in a full/ subdirectory, so we construct those paths.
-    cropped_ortho = dataset_dir / "full" / "cropped_ortho.tif"
-    cropped_chm = dataset_dir / "full" / "cropped_chm.tif"
 
     # Check that the cropped files were created successfully
     for f in [cropped_ortho, cropped_chm]:


### PR DESCRIPTION
Added a script to handle the preprocessing steps in the TDF Argo workflow. It must live in the `postprocessing` folder since the script is importing `crop_raster_save_cog` which has been implemented in the `postprocessing` module, so I don't see a way around it.